### PR TITLE
build_dockers: new directory structure

### DIFF
--- a/build_dockers.bsh
+++ b/build_dockers.bsh
@@ -20,26 +20,26 @@ export GOLANG_VERSION
 export DOCKER_LFS_BUILD_VERSION=${DOCKER_LFS_BUILD_VERSION:-release-1.3}
 
 if [[ $# == 0 ]]; then
-  IMAGE_NAMES=($(ls -d ${CUR_DIR}/*/*/Dockerfile))
+  IMAGE_NAMES=($(ls -d ${CUR_DIR}/*.Dockerfile))
 else
   IMAGE_NAMES=("${@}")
 fi
 
 #This will take a long time the first time
 for IMAGE_NAME in "${IMAGE_NAMES[@]}"; do
-  # IMAGE_NAME is "./debian/7/Dockerfile"
+  # IMAGE_NAME is "./debian_7.Dockerfile"
   # strip basename
-  # strip leading non whitespace
-  # convert / to _
+  # strip leading "./"
+  # strip trailing ".Dockerfile"
   IMAGE_DIR=$(dirname ${IMAGE_NAME})
-  NAME=$(printf $IMAGE_DIR | sed 's/[\.\/]*//' | sed 's/\//_/')
+  NAME="$(printf $IMAGE_NAME | sed 's/\.\///' | sed 's/\.Dockerfile$//')"
 
   pushd $IMAGE_DIR
     echo Docker building ${NAME}
     if [[ $IMAGE_NAME == centos* ]]; then
-      $SUDO docker build --build-arg=GOLANG_VERSION=${GOLANG_VERSION} --build-arg=DOCKER_LFS_BUILD_VERSION=${DOCKER_LFS_BUILD_VERSION} -t gitlfs/linux_packages:${NAME} -f Dockerfile ${CUR_DIR}
+      $SUDO docker build --build-arg=GOLANG_VERSION=${GOLANG_VERSION} --build-arg=DOCKER_LFS_BUILD_VERSION=${DOCKER_LFS_BUILD_VERSION} -t gitlfs/linux_packages:${NAME} -f "$NAME.Dockerfile" .
     else
-      $SUDO docker build --build-arg=GOLANG_VERSION=${GOLANG_VERSION} -t gitlfs/linux_packages:${NAME} -f Dockerfile ${CUR_DIR}
+      $SUDO docker build --build-arg=GOLANG_VERSION=${GOLANG_VERSION} -t gitlfs/linux_packages:${NAME} -f "$NAME.Dockerfile" .
     fi
   popd
 done


### PR DESCRIPTION
This pull-request teaches the `build_dockers.bsh` script to interact with the new directory structure introduced in e575ec73ced3d006e8b75641ac132931d55cde84.

I can break this change down into a few parts:

- Fix the `ls -d` glob to search for all of the `Dockerfile`s.
- Fix both `sed` invocations to produce a correct image name.
- Fix the `docker build` invocation to point at the correct directory.

--

/cc @technoweenie @rubyist @andyneff 