### PR TITLE
all: rename org from github to git-lfs

### DIFF
--- a/centos_6.Dockerfile
+++ b/centos_6.Dockerfile
@@ -24,12 +24,12 @@ RUN cd /usr/local && \
 #the docker will not build, so I decided to make a stable version the default
 ARG DOCKER_LFS_BUILD_VERSION=release-1.4
 
-ADD https://github.com/github/git-lfs/archive/${DOCKER_LFS_BUILD_VERSION}.tar.gz /tmp/docker_setup/
+ADD https://github.com/git-lfs/git-lfs/archive/${DOCKER_LFS_BUILD_VERSION}.tar.gz /tmp/docker_setup/
 RUN cd /tmp/docker_setup/; \
     tar zxf ${DOCKER_LFS_BUILD_VERSION}.tar.gz; \
-    mkdir -p src/github.com/github; \
-    mv git-lfs-* src/github.com/github/git-lfs; \
-    cd /tmp/docker_setup/src/github.com/github/git-lfs/rpm; \
+    mkdir -p src/github.com/git-lfs; \
+    mv git-lfs-* src/github.com/git-lfs/git-lfs; \
+    cd /tmp/docker_setup/src/github.com/git-lfs/git-lfs/rpm; \
     touch build.log; \
     tail -f build.log & GOPATH=/tmp/docker_setup ./build_rpms.bsh; \
     rm -rf /tmp/docker_setup

--- a/centos_7.Dockerfile
+++ b/centos_7.Dockerfile
@@ -24,12 +24,12 @@ RUN cd /usr/local && \
 #the docker will not build, so I decided to make a stable version the default
 ARG DOCKER_LFS_BUILD_VERSION=release-1.4
 
-ADD https://github.com/github/git-lfs/archive/${DOCKER_LFS_BUILD_VERSION}.tar.gz /tmp/docker_setup/
+ADD https://github.com/git-lfs/git-lfs/archive/${DOCKER_LFS_BUILD_VERSION}.tar.gz /tmp/docker_setup/
 RUN cd /tmp/docker_setup/; \
     tar zxf ${DOCKER_LFS_BUILD_VERSION}.tar.gz; \
-    mkdir -p src/github.com/github; \
-    mv git-lfs-* src/github.com/github/git-lfs; \
-    cd /tmp/docker_setup/src/github.com/github/git-lfs/rpm; \
+    mkdir -p src/github.com/git-lfs; \
+    mv git-lfs-* src/github.com/git-lfs/git-lfs; \
+    cd /tmp/docker_setup/src/github.com/git-lfs/git-lfs/rpm; \
     touch build.log; \
     tail -f build.log & GOPATH=/tmp/docker_setup ./build_rpms.bsh; \
     rm -rf /tmp/docker_setup

--- a/centos_script.bsh
+++ b/centos_script.bsh
@@ -4,7 +4,7 @@ set -eu
 
 REPO_DIR=${REPO_DIR:-/repo}
 export GOPATH=${GOPATH:-/tmp/docker_run}
-GIT_LFS_BUILD_DIR=${GIT_LFS_BUILD_DIR:-$GOPATH/src/github.com/github/git-lfs}
+GIT_LFS_BUILD_DIR=${GIT_LFS_BUILD_DIR:-$GOPATH/src/github.com/git-lfs/git-lfs}
 SRC_DIR=${SRC_DIR:-/src}
 
 if [ -e /etc/os-release ]; then

--- a/debian_script.bsh
+++ b/debian_script.bsh
@@ -4,7 +4,7 @@ set -eu
 
 export GOPATH="${GOPATH:-/tmp/docker_run}:/usr/share/gocode"
 REPO_DIR=${REPO_DIR:-/repo}
-GIT_LFS_BUILD_DIR=${GIT_LFS_BUILD_DIR:-/tmp/docker_run/src/github.com/github/git-lfs}
+GIT_LFS_BUILD_DIR=${GIT_LFS_BUILD_DIR:-/tmp/docker_run/src/github.com/git-lfs/git-lfs}
 SRC_DIR=${SRC_DIR:-/src}
 REPO_CODENAME=${REPO_CODENAME:-$(source /etc/os-release; echo $VERSION | sed -r 's|.*\((.*)\)|\1|')}
 

--- a/test_lfs.bsh
+++ b/test_lfs.bsh
@@ -9,8 +9,8 @@ git config --global user.name "Your Name"
 
 cp -ra /src /tmp/test/
 cd /tmp/test
-mkdir -p ./src/github.com/github
-unlink src/github.com/github/git-lfs || :
-ln -sf $(pwd) src/github.com/github/git-lfs
+mkdir -p ./src/github.com/git-lfs
+unlink src/github.com/git-lfs/git-lfs || :
+ln -sf $(pwd) src/github.com/git-lfs/git-lfs
 LFS_BIN=1 GOPATH=$(pwd) ./script/test
 LFS_BIN=1 GOPATH=$(pwd) ./script/integration


### PR DESCRIPTION
This pull-request renames all uses of `github.com/github/git-lfs` to `github.com/git-lfs/git-lfs` to reflect the recent org change.

```bash
~/g/build-dockers (rename-org) $ ack "github\.com/github/git-lfs"
~/g/build-dockers (rename-org) $
```

---

/cc @andyneff @technoweenie 