### PR TITLE
all: bootstrap using `release-1.5` tree

### DIFF
--- a/build_dockers.bsh
+++ b/build_dockers.bsh
@@ -17,7 +17,7 @@ export GOLANG_VERSION
 #If you are not in docker group and you have sudo, default value is sudo
 : ${SUDO=`if ( [ ! -w /var/run/docker.sock ] && id -nG | grep -qwv docker && [ "${DOCKER_HOST:+dh}" != "dh" ] ) && which sudo > /dev/null 2>&1; then echo sudo; fi`}
 
-export DOCKER_LFS_BUILD_VERSION=${DOCKER_LFS_BUILD_VERSION:-release-1.4}
+export DOCKER_LFS_BUILD_VERSION=${DOCKER_LFS_BUILD_VERSION:-release-1.5}
 
 if [[ $# == 0 ]]; then
   IMAGE_NAMES=($(ls -d ${CUR_DIR}/*.Dockerfile))

--- a/centos_6.Dockerfile
+++ b/centos_6.Dockerfile
@@ -22,7 +22,7 @@ RUN cd /usr/local && \
 
 #Set to master if you want the latest, but IF there is a failure,
 #the docker will not build, so I decided to make a stable version the default
-ARG DOCKER_LFS_BUILD_VERSION=release-1.4
+ARG DOCKER_LFS_BUILD_VERSION=release-1.5
 
 ADD https://github.com/git-lfs/git-lfs/archive/${DOCKER_LFS_BUILD_VERSION}.tar.gz /tmp/docker_setup/
 RUN cd /tmp/docker_setup/; \

--- a/centos_7.Dockerfile
+++ b/centos_7.Dockerfile
@@ -22,7 +22,7 @@ RUN cd /usr/local && \
 
 #Set to master if you want the latest, but IF there is a failure,
 #the docker will not build, so I decided to make a stable version the default
-ARG DOCKER_LFS_BUILD_VERSION=release-1.4
+ARG DOCKER_LFS_BUILD_VERSION=release-1.5
 
 ADD https://github.com/git-lfs/git-lfs/archive/${DOCKER_LFS_BUILD_VERSION}.tar.gz /tmp/docker_setup/
 RUN cd /tmp/docker_setup/; \

--- a/commit_tags.bsh
+++ b/commit_tags.bsh
@@ -7,7 +7,7 @@ cd $(dirname "${BASH_SOURCE[0]}")
 : ${GOLANG_VERSION:=1.5.3}
 export GOLANG_VERSION
 
-export DOCKER_LFS_BUILD_VERSION=${DOCKER_LFS_BUILD_VERSION:-release-1.4}
+export DOCKER_LFS_BUILD_VERSION=${DOCKER_LFS_BUILD_VERSION:-release-1.5}
 
 
 if ! git diff --cached --exit-code >/dev/null 2>&1 || ! git diff --exit-code >/dev/null 2>&1; then


### PR DESCRIPTION
Previously, the version of LFS that we used to boostrap used the old naming
convention: 'github.com/github/git-lfs". The Dockerfiles in this repository
assume the latest naming convention "github.com/git-lfs/git-lfs".

This commit bumps the bootstrapped version to `release-1.5` so we can start
using the new naming conventions throughout.

---

/cc @technoweenie @andyneff 