### PR TITLE
all: build using Go 1.8.1

### DIFF
--- a/build_dockers.bsh
+++ b/build_dockers.bsh
@@ -11,7 +11,7 @@ set -eu
 
 CUR_DIR=$(dirname "${BASH_SOURCE[0]}")
 
-: ${GOLANG_VERSION:=1.8}
+: ${GOLANG_VERSION:=1.8.1}
 export GOLANG_VERSION
 
 #If you are not in docker group and you have sudo, default value is sudo

--- a/centos_6.Dockerfile
+++ b/centos_6.Dockerfile
@@ -6,7 +6,7 @@ LABEL RUN="docker run -v git-lfs-repo-dir:/src -v repo_dir:/repo"
 
 RUN yum install -y epel-release rsync tar
 
-ARG GOLANG_VERSION=1.8
+ARG GOLANG_VERSION=1.8.1
 
 ENV GOROOT=/usr/local/go
 

--- a/centos_7.Dockerfile
+++ b/centos_7.Dockerfile
@@ -6,7 +6,7 @@ LABEL RUN="docker run -v git-lfs-repo-dir:/src -v repo_dir:/repo"
 
 RUN yum install -y rsync git ruby ruby-devel gcc
 
-ARG GOLANG_VERSION=1.8
+ARG GOLANG_VERSION=1.8.1
 
 ENV GOROOT=/usr/local/go
 

--- a/debian_7.Dockerfile
+++ b/debian_7.Dockerfile
@@ -9,7 +9,7 @@ RUN echo 'deb http://http.debian.net/debian wheezy-backports main' > /etc/apt/so
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y update && \
 apt-get install -y -t wheezy-backports git dpkg-dev dh-golang ruby-ronn curl
 
-ARG GOLANG_VERSION=1.8
+ARG GOLANG_VERSION=1.8.1
 
 ENV GOROOT=/usr/local/go
 

--- a/debian_8.Dockerfile
+++ b/debian_8.Dockerfile
@@ -7,7 +7,7 @@ LABEL RUN="docker run -v git-lfs-checkout-dir:/src -v repo_dir:/repo"
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y update && \
 apt-get install -y git dpkg-dev dh-golang ruby-ronn curl
 
-ARG GOLANG_VERSION=1.8
+ARG GOLANG_VERSION=1.8.1
 
 ENV GOROOT=/usr/local/go
 

--- a/debian_9.Dockerfile
+++ b/debian_9.Dockerfile
@@ -7,7 +7,7 @@ LABEL RUN="docker run -v git-lfs-checkout-dir:/src -v repo_dir:/repo"
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y update && \
 apt-get install -y git dpkg-dev dh-golang ruby-ronn curl
 
-ARG GOLANG_VERSION=1.8
+ARG GOLANG_VERSION=1.8.1
 
 ENV GOROOT=/usr/local/go
 


### PR DESCRIPTION
This pull request resolves the other component of https://github.com/git-lfs/git-lfs/issues/2141 and builds all Git LFS Linux packages on Go 1.8.1.

---

/cc @git-lfs/core 