### PR TITLE
all: build against Go 1.8.3

### DIFF
--- a/build_dockers.bsh
+++ b/build_dockers.bsh
@@ -11,7 +11,7 @@ set -eu
 
 CUR_DIR=$(dirname "${BASH_SOURCE[0]}")
 
-: ${GOLANG_VERSION:=1.8.1}
+: ${GOLANG_VERSION:=1.8.3}
 export GOLANG_VERSION
 
 #If you are not in docker group and you have sudo, default value is sudo

--- a/centos_6.Dockerfile
+++ b/centos_6.Dockerfile
@@ -6,7 +6,7 @@ LABEL RUN="docker run -v git-lfs-repo-dir:/src -v repo_dir:/repo"
 
 RUN yum install -y epel-release rsync tar
 
-ARG GOLANG_VERSION=1.8.1
+ARG GOLANG_VERSION=1.8.3
 
 ENV GOROOT=/usr/local/go
 

--- a/centos_7.Dockerfile
+++ b/centos_7.Dockerfile
@@ -6,7 +6,7 @@ LABEL RUN="docker run -v git-lfs-repo-dir:/src -v repo_dir:/repo"
 
 RUN yum install -y rsync git ruby ruby-devel gcc
 
-ARG GOLANG_VERSION=1.8.1
+ARG GOLANG_VERSION=1.8.3
 
 ENV GOROOT=/usr/local/go
 

--- a/commit_tags.bsh
+++ b/commit_tags.bsh
@@ -4,7 +4,7 @@ set -eu
 
 cd $(dirname "${BASH_SOURCE[0]}")
 
-: ${GOLANG_VERSION:=1.5.3}
+: ${GOLANG_VERSION:=1.8.3}
 export GOLANG_VERSION
 
 export DOCKER_LFS_BUILD_VERSION=${DOCKER_LFS_BUILD_VERSION:-release-1.5}

--- a/commit_tags.bsh
+++ b/commit_tags.bsh
@@ -7,7 +7,7 @@ cd $(dirname "${BASH_SOURCE[0]}")
 : ${GOLANG_VERSION:=1.8.3}
 export GOLANG_VERSION
 
-export DOCKER_LFS_BUILD_VERSION=${DOCKER_LFS_BUILD_VERSION:-release-1.5}
+export DOCKER_LFS_BUILD_VERSION=${DOCKER_LFS_BUILD_VERSION:-release-2.1}
 
 
 if ! git diff --cached --exit-code >/dev/null 2>&1 || ! git diff --exit-code >/dev/null 2>&1; then

--- a/debian_7.Dockerfile
+++ b/debian_7.Dockerfile
@@ -9,7 +9,7 @@ RUN echo 'deb http://http.debian.net/debian wheezy-backports main' > /etc/apt/so
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y update && \
 apt-get install -y -t wheezy-backports git dpkg-dev dh-golang ruby-ronn curl
 
-ARG GOLANG_VERSION=1.8.1
+ARG GOLANG_VERSION=1.8.3
 
 ENV GOROOT=/usr/local/go
 

--- a/debian_8.Dockerfile
+++ b/debian_8.Dockerfile
@@ -7,7 +7,7 @@ LABEL RUN="docker run -v git-lfs-checkout-dir:/src -v repo_dir:/repo"
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y update && \
 apt-get install -y git dpkg-dev dh-golang ruby-ronn curl
 
-ARG GOLANG_VERSION=1.8.1
+ARG GOLANG_VERSION=1.8.3
 
 ENV GOROOT=/usr/local/go
 

--- a/debian_9.Dockerfile
+++ b/debian_9.Dockerfile
@@ -7,7 +7,7 @@ LABEL RUN="docker run -v git-lfs-checkout-dir:/src -v repo_dir:/repo"
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y update && \
 apt-get install -y git dpkg-dev dh-golang ruby-ronn curl
 
-ARG GOLANG_VERSION=1.8.1
+ARG GOLANG_VERSION=1.8.3
 
 ENV GOROOT=/usr/local/go
 


### PR DESCRIPTION
This pull request upgrades our Docker images to build using Go 1.8.3. For more discussion, see: https://github.com/git-lfs/git-lfs/pull/2262.

While I was upgrading, I noticed that our commit_tags script bootstraps using an old version of LFS and Go, so I upgraded both to the latest to match.

---

/cc @git-lfs/core 