### PR TITLE
centos: install latest version of Git

### DIFF
--- a/centos_6.Dockerfile
+++ b/centos_6.Dockerfile
@@ -5,6 +5,14 @@ MAINTAINER Andy Neff <andyneff@users.noreply.github.com>
 LABEL RUN="docker run -v git-lfs-repo-dir:/src -v repo_dir:/repo"
 
 RUN yum install -y epel-release rsync tar
+RUN yum install -y gettext-devel openssl-devel perl-CPAN perl-devel zlib-devel make wget autoconf && \
+  wget https://github.com/git/git/archive/v2.16.0.tar.gz -O git.tar.gz && \
+  tar -zxf git.tar.gz && \
+  cd git-* && \
+  make configure && \
+  ./configure --prefix=/usr/local && \
+  make install && \
+  git --version
 
 ARG GOLANG_VERSION=1.8.3
 

--- a/centos_7.Dockerfile
+++ b/centos_7.Dockerfile
@@ -4,7 +4,15 @@ MAINTAINER Andy Neff <andyneff@users.noreply.github.com>
 #Docker RUN example, pass in the git-lfs checkout copy you are working with
 LABEL RUN="docker run -v git-lfs-repo-dir:/src -v repo_dir:/repo"
 
-RUN yum install -y rsync git ruby ruby-devel gcc
+RUN yum install -y rsync ruby ruby-devel gcc
+RUN yum install -y gettext-devel openssl-devel perl-CPAN perl-devel zlib-devel make wget autoconf && \
+  wget https://github.com/git/git/archive/v2.16.0.tar.gz -O git.tar.gz && \
+  tar -zxf git.tar.gz && \
+  cd git-* && \
+  make configure && \
+  ./configure --prefix=/usr/local && \
+  make install && \
+  git --version
 
 ARG GOLANG_VERSION=1.8.3
 


### PR DESCRIPTION
This pull request builds Git LFS on Centos 6, and Centos 7 using the latest MINOR version of Git, v2.16.0. This is necessary in order to support additional functionality added in Git LFS v2.4.0

##

/cc @git-lfs/core 