### PR TITLE
test_lfs.bsh: replace script invocations with make targets

### DIFF
--- a/test_lfs.bsh
+++ b/test_lfs.bsh
@@ -12,5 +12,5 @@ cd /tmp/test
 mkdir -p ./src/github.com/git-lfs
 unlink src/github.com/git-lfs/git-lfs || :
 ln -sf $(pwd) src/github.com/git-lfs/git-lfs
-LFS_BIN=1 GOPATH=$(pwd) ./script/test
-LFS_BIN=1 GOPATH=$(pwd) ./script/integration
+LFS_BIN=1 GOPATH=$(pwd) make test
+LFS_BIN=1 GOPATH=$(pwd) make -C t test


### PR DESCRIPTION
In [1] and [2], Git LFS learned how to run its tests under prove(1) and
replaced many of its script/*'s with Makefile-based targets.

The platform-specific instructions for building `*.deb`'s and `*.rpm`'s
must update accordingly so as not to refer to outdated (and now broken
invocations) such as script/test. For example, this particular
invocation--script/test--should be replaced with 'make test' instead.

Apply the necessary changes to avoid bitrot and keep the Git LFS
script/target invocations up-to-date.

##

/cc @git-lfs/core 

[1]: https://github.com/git-lfs/git-lfs/pull/3125
[2]: https://github.com/git-lfs/git-lfs/pull/3144