### PR TITLE
{build,push}_docker.bsh: use up-to-date image name

### DIFF
--- a/build_dockers.bsh
+++ b/build_dockers.bsh
@@ -37,9 +37,9 @@ for IMAGE_NAME in "${IMAGE_NAMES[@]}"; do
   pushd $IMAGE_DIR
     echo Docker building ${NAME}
     if [[ $IMAGE_NAME == centos* ]]; then
-      $SUDO docker build --build-arg=GOLANG_VERSION=${GOLANG_VERSION} --build-arg=DOCKER_LFS_BUILD_VERSION=${DOCKER_LFS_BUILD_VERSION} -t gitlfs/linux_packages:${NAME} -f "$NAME.Dockerfile" .
+      $SUDO docker build --build-arg=GOLANG_VERSION=${GOLANG_VERSION} --build-arg=DOCKER_LFS_BUILD_VERSION=${DOCKER_LFS_BUILD_VERSION} -t gitlfs/build-dockers:${NAME} -f "$NAME.Dockerfile" .
     else
-      $SUDO docker build --build-arg=GOLANG_VERSION=${GOLANG_VERSION} -t gitlfs/linux_packages:${NAME} -f "$NAME.Dockerfile" .
+      $SUDO docker build --build-arg=GOLANG_VERSION=${GOLANG_VERSION} -t gitlfs/build-dockers:${NAME} -f "$NAME.Dockerfile" .
     fi
   popd
 done

--- a/push_docker.bsh
+++ b/push_docker.bsh
@@ -57,7 +57,7 @@ for DOCKER_FILE in "${IMAGES[@]}"; do
     ${CUR_DIR}/build_dockers.bsh ${DOCKER_FILE}
   fi
 
-  $SUDO docker push gitlfs/linux_packages:${IMAGE_NAME}
+  $SUDO docker push gitlfs/build-dockers:${IMAGE_NAME}
 
 done
 


### PR DESCRIPTION
In [1], Git LFS began using packages from Docker Hub [2] to bootstrap
platform-specific '*.deb' and '*.rpm' packages using the 'gitlfs'
organization handle.

When building and pushing Docker images, let's use the same name. This
has the benefit of again allowing us to build Docker images locally that
are used by Git LFS, such that a release maintainer can build packages
themselves.

This flow does not require the user to invoke Docker Hub (or have a
network connection, save for getting the latest upstream debian or
centos images) and allows for a fast feedback loop when developing.

##

/cc @git-lfs/core 

[1]: git-lfs@b15ca36f (run against gitlfs packages from docker hub,
     2016-08-02)
[2]: https://hub.docker.com