### PR TITLE
all: build against Go 1.11

### DIFF
--- a/build_dockers.bsh
+++ b/build_dockers.bsh
@@ -11,7 +11,7 @@ set -eu
 
 CUR_DIR=$(dirname "${BASH_SOURCE[0]}")
 
-: ${GOLANG_VERSION:=1.10.3}
+: ${GOLANG_VERSION:=1.11}
 export GOLANG_VERSION
 
 #If you are not in docker group and you have sudo, default value is sudo

--- a/build_dockers.bsh
+++ b/build_dockers.bsh
@@ -17,7 +17,7 @@ export GOLANG_VERSION
 #If you are not in docker group and you have sudo, default value is sudo
 : ${SUDO=`if ( [ ! -w /var/run/docker.sock ] && id -nG | grep -qwv docker && [ "${DOCKER_HOST:+dh}" != "dh" ] ) && which sudo > /dev/null 2>&1; then echo sudo; fi`}
 
-export DOCKER_LFS_BUILD_VERSION=${DOCKER_LFS_BUILD_VERSION:-release-1.5}
+export DOCKER_LFS_BUILD_VERSION=${DOCKER_LFS_BUILD_VERSION:-release-2.4}
 
 if [[ $# == 0 ]]; then
   IMAGE_NAMES=($(ls -d ${CUR_DIR}/*.Dockerfile))

--- a/centos_6.Dockerfile
+++ b/centos_6.Dockerfile
@@ -14,7 +14,7 @@ RUN yum install -y gcc libcurl-devel gettext-devel openssl-devel perl-CPAN perl-
   make install && \
   git --version
 
-ARG GOLANG_VERSION=1.10.3
+ARG GOLANG_VERSION=1.11
 
 ENV GOROOT=/usr/local/go
 

--- a/centos_6.Dockerfile
+++ b/centos_6.Dockerfile
@@ -34,12 +34,11 @@ ARG DOCKER_LFS_BUILD_VERSION=release-1.5
 
 ADD https://github.com/git-lfs/git-lfs/archive/${DOCKER_LFS_BUILD_VERSION}.tar.gz /tmp/docker_setup/
 RUN cd /tmp/docker_setup/; \
-    tar zxf ${DOCKER_LFS_BUILD_VERSION}.tar.gz; \
-    mkdir -p src/github.com/git-lfs; \
-    mv git-lfs-* src/github.com/git-lfs/git-lfs; \
-    cd /tmp/docker_setup/src/github.com/git-lfs/git-lfs/rpm; \
+    mkdir -p src/git-lfs; \
+    tar -Csrc/git-lfs -zxf ${DOCKER_LFS_BUILD_VERSION}.tar.gz; \
+    cd /tmp/docker_setup/src/git-lfs/rpm; \
     touch build.log; \
-    tail -f build.log & GOPATH=/tmp/docker_setup ./build_rpms.bsh; \
+    tail -f build.log & ./build_rpms.bsh; \
     rm -rf /tmp/docker_setup
 
 #Add the simple build repo script

--- a/centos_6.Dockerfile
+++ b/centos_6.Dockerfile
@@ -30,7 +30,7 @@ RUN cd /usr/local && \
 
 #Set to master if you want the latest, but IF there is a failure,
 #the docker will not build, so I decided to make a stable version the default
-ARG DOCKER_LFS_BUILD_VERSION=release-1.5
+ARG DOCKER_LFS_BUILD_VERSION=release-2.4
 
 ADD https://github.com/git-lfs/git-lfs/archive/${DOCKER_LFS_BUILD_VERSION}.tar.gz /tmp/docker_setup/
 RUN cd /tmp/docker_setup/; \

--- a/centos_7.Dockerfile
+++ b/centos_7.Dockerfile
@@ -34,12 +34,13 @@ ARG DOCKER_LFS_BUILD_VERSION=release-1.5
 
 ADD https://github.com/git-lfs/git-lfs/archive/${DOCKER_LFS_BUILD_VERSION}.tar.gz /tmp/docker_setup/
 RUN cd /tmp/docker_setup/; \
-    tar zxf ${DOCKER_LFS_BUILD_VERSION}.tar.gz; \
-    mkdir -p src/github.com/git-lfs; \
-    mv git-lfs-* src/github.com/git-lfs/git-lfs; \
-    cd /tmp/docker_setup/src/github.com/git-lfs/git-lfs/rpm; \
+    mkdir -p src; \
+    cd src; \
+    tar -zxf ../${DOCKER_LFS_BUILD_VERSION}.tar.gz; \
+    mv git-lfs-${DOCKER_LFS_BUILD_VERSION} git-lfs; \
+    cd /tmp/docker_setup/src/git-lfs/rpm; \
     touch build.log; \
-    tail -f build.log & GOPATH=/tmp/docker_setup ./build_rpms.bsh; \
+    tail -f build.log & ./build_rpms.bsh; \
     rm -rf /tmp/docker_setup
 
 #Add the simple build repo script

--- a/centos_7.Dockerfile
+++ b/centos_7.Dockerfile
@@ -14,7 +14,7 @@ RUN yum install -y gettext-devel libcurl-devel openssl-devel perl-CPAN perl-deve
   make install && \
   git --version
 
-ARG GOLANG_VERSION=1.10.3
+ARG GOLANG_VERSION=1.11
 
 ENV GOROOT=/usr/local/go
 

--- a/centos_7.Dockerfile
+++ b/centos_7.Dockerfile
@@ -30,7 +30,7 @@ RUN cd /usr/local && \
 
 #Set to master if you want the latest, but IF there is a failure,
 #the docker will not build, so I decided to make a stable version the default
-ARG DOCKER_LFS_BUILD_VERSION=release-1.5
+ARG DOCKER_LFS_BUILD_VERSION=release-2.4
 
 ADD https://github.com/git-lfs/git-lfs/archive/${DOCKER_LFS_BUILD_VERSION}.tar.gz /tmp/docker_setup/
 RUN cd /tmp/docker_setup/; \

--- a/centos_script.bsh
+++ b/centos_script.bsh
@@ -3,8 +3,7 @@
 set -eu
 
 REPO_DIR=${REPO_DIR:-/repo}
-export GOPATH=${GOPATH:-/tmp/docker_run}
-GIT_LFS_BUILD_DIR=${GIT_LFS_BUILD_DIR:-$GOPATH/src/github.com/git-lfs/git-lfs}
+GIT_LFS_BUILD_DIR=${GIT_LFS_BUILD_DIR:-$HOME/src/git-lfs}
 SRC_DIR=${SRC_DIR:-/src}
 
 if [ -e /etc/os-release ]; then

--- a/commit_tags.bsh
+++ b/commit_tags.bsh
@@ -4,7 +4,7 @@ set -eu
 
 cd $(dirname "${BASH_SOURCE[0]}")
 
-: ${GOLANG_VERSION:=1.10.3}
+: ${GOLANG_VERSION:=1.11}
 export GOLANG_VERSION
 
 export DOCKER_LFS_BUILD_VERSION=${DOCKER_LFS_BUILD_VERSION:-release-2.1}

--- a/debian_7.Dockerfile
+++ b/debian_7.Dockerfile
@@ -9,7 +9,7 @@ RUN echo 'deb http://http.debian.net/debian wheezy-backports main' > /etc/apt/so
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y update && \
 apt-get install -y -t wheezy-backports git dpkg-dev dh-golang ruby-ronn curl
 
-ARG GOLANG_VERSION=1.10.3
+ARG GOLANG_VERSION=1.11
 
 ENV GOROOT=/usr/local/go
 

--- a/debian_8.Dockerfile
+++ b/debian_8.Dockerfile
@@ -7,7 +7,7 @@ LABEL RUN="docker run -v git-lfs-checkout-dir:/src -v repo_dir:/repo"
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y update && \
 apt-get install -y git dpkg-dev dh-golang ruby-ronn curl
 
-ARG GOLANG_VERSION=1.10.3
+ARG GOLANG_VERSION=1.11
 
 ENV GOROOT=/usr/local/go
 

--- a/debian_9.Dockerfile
+++ b/debian_9.Dockerfile
@@ -7,7 +7,7 @@ LABEL RUN="docker run -v git-lfs-checkout-dir:/src -v repo_dir:/repo"
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y update && \
 apt-get install -y git dpkg-dev dh-golang ruby-ronn curl
 
-ARG GOLANG_VERSION=1.10.3
+ARG GOLANG_VERSION=1.11
 
 ENV GOROOT=/usr/local/go
 

--- a/debian_script.bsh
+++ b/debian_script.bsh
@@ -2,9 +2,8 @@
 
 set -eu
 
-export GOPATH="${GOPATH:-/tmp/docker_run}:/usr/share/gocode"
 REPO_DIR=${REPO_DIR:-/repo}
-GIT_LFS_BUILD_DIR=${GIT_LFS_BUILD_DIR:-/tmp/docker_run/src/github.com/git-lfs/git-lfs}
+GIT_LFS_BUILD_DIR=${GIT_LFS_BUILD_DIR:-/tmp/docker_run/src/git-lfs}
 SRC_DIR=${SRC_DIR:-/src}
 REPO_CODENAME=${REPO_CODENAME:-$(source /etc/os-release; echo $VERSION | sed -r 's|.*\((.*)\)|\1|')}
 


### PR DESCRIPTION
Because of a change in Go's package go/ast, the gofmt tool formats
certain whitespace changes differently between versions Go 1.10 and Go
1.11. To resolve this ambiguity in versions, let's upgrade Git LFS to
built on Go 1.11, after having waited several weeks since its release.

In order to release another version in the v2.5.x-series, a release
manager must ensure that they are using the non-Go 1.11 images (i.e.,
42a794c (Merge pull request #22 from git-lfs/ttaylorr/go-1.10.3,
2018-07-25) or earlier).

##

/cc @git-lfs/core 