### PR TITLE
Update Go version to 1.13.1

### DIFF
--- a/build_dockers.bsh
+++ b/build_dockers.bsh
@@ -11,7 +11,7 @@ set -eu
 
 CUR_DIR=$(dirname "${BASH_SOURCE[0]}")
 
-: ${GOLANG_VERSION:=1.12.6}
+: ${GOLANG_VERSION:=1.13.1}
 export GOLANG_VERSION
 
 #If you are not in docker group and you have sudo, default value is sudo

--- a/centos_6.Dockerfile
+++ b/centos_6.Dockerfile
@@ -14,7 +14,7 @@ RUN yum install -y gcc libcurl-devel gettext-devel openssl-devel perl-CPAN perl-
   make install && \
   git --version
 
-ARG GOLANG_VERSION=1.12.6
+ARG GOLANG_VERSION=1.13.1
 
 ENV GOROOT=/usr/local/go
 

--- a/centos_7.Dockerfile
+++ b/centos_7.Dockerfile
@@ -14,7 +14,7 @@ RUN yum install -y gettext-devel libcurl-devel openssl-devel perl-CPAN perl-deve
   make install && \
   git --version
 
-ARG GOLANG_VERSION=1.12.6
+ARG GOLANG_VERSION=1.13.1
 
 ENV GOROOT=/usr/local/go
 

--- a/commit_tags.bsh
+++ b/commit_tags.bsh
@@ -4,7 +4,7 @@ set -eu
 
 cd $(dirname "${BASH_SOURCE[0]}")
 
-: ${GOLANG_VERSION:=1.12.6}
+: ${GOLANG_VERSION:=1.13.1}
 export GOLANG_VERSION
 
 export DOCKER_LFS_BUILD_VERSION=${DOCKER_LFS_BUILD_VERSION:-release-2.1}

--- a/debian_10.Dockerfile
+++ b/debian_10.Dockerfile
@@ -6,7 +6,7 @@ LABEL RUN="docker run -v git-lfs-checkout-dir:/src -v repo_dir:/repo"
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y update && \
 apt-get install -y git dpkg-dev dh-golang ruby-ronn ronn curl
 
-ARG GOLANG_VERSION=1.12.6
+ARG GOLANG_VERSION=1.13.1
 
 ENV GOROOT=/usr/local/go
 

--- a/debian_8.Dockerfile
+++ b/debian_8.Dockerfile
@@ -7,7 +7,7 @@ LABEL RUN="docker run -v git-lfs-checkout-dir:/src -v repo_dir:/repo"
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y update && \
 apt-get install -y git dpkg-dev dh-golang ruby-ronn curl
 
-ARG GOLANG_VERSION=1.12.6
+ARG GOLANG_VERSION=1.13.1
 
 ENV GOROOT=/usr/local/go
 

--- a/debian_9.Dockerfile
+++ b/debian_9.Dockerfile
@@ -7,7 +7,7 @@ LABEL RUN="docker run -v git-lfs-checkout-dir:/src -v repo_dir:/repo"
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y update && \
 apt-get install -y git dpkg-dev dh-golang ruby-ronn curl
 
-ARG GOLANG_VERSION=1.12.6
+ARG GOLANG_VERSION=1.13.1
 
 ENV GOROOT=/usr/local/go
 


### PR DESCRIPTION
This will bump the latest go security patch for 1.12. I wasn't sure if this should go directly to 1.13