### PR TITLE
Add a Dockerfile for CentOS 8

### DIFF
--- a/centos_8.Dockerfile
+++ b/centos_8.Dockerfile
@@ -1,0 +1,18 @@
+FROM centos:8
+
+RUN yum install -y rsync ruby ruby-devel gcc
+RUN yum install -y gettext-devel libcurl-devel openssl-devel perl-CPAN perl-devel zlib-devel make wget autoconf git
+
+ARG GOLANG_VERSION=1.13.1
+
+ENV GOROOT=/usr/local/go
+
+RUN cd /usr/local && \
+    curl -L -O https://storage.googleapis.com/golang/go${GOLANG_VERSION}.linux-amd64.tar.gz && \
+    tar zxf go${GOLANG_VERSION}.linux-amd64.tar.gz && \
+    ln -s /usr/local/go/bin/go /usr/bin/go && \
+    ln -s /usr/local/go/bin/gofmt /usr/bin/gofmt
+
+COPY centos_script.bsh /tmp/
+
+CMD /tmp/centos_script.bsh


### PR DESCRIPTION
CentOS 8 is now released and has Docker images, so build a Docker image for it.