### PR TITLE
centos: don't build Git LFS during setup

### DIFF
--- a/centos_6.Dockerfile
+++ b/centos_6.Dockerfile
@@ -24,23 +24,6 @@ RUN cd /usr/local && \
     ln -s /usr/local/go/bin/go /usr/bin/go && \
     ln -s /usr/local/go/bin/gofmt /usr/bin/gofmt
 
-#The purpose of this is to build and install everything needed to build git-lfs
-#Next time. So that the LONG build/installed in centos are only done once, and
-#stored in the image.
-
-#Set to master if you want the latest, but IF there is a failure,
-#the docker will not build, so I decided to make a stable version the default
-ARG DOCKER_LFS_BUILD_VERSION=release-2.4
-
-ADD https://github.com/git-lfs/git-lfs/archive/${DOCKER_LFS_BUILD_VERSION}.tar.gz /tmp/docker_setup/
-RUN cd /tmp/docker_setup/; \
-    mkdir -p src/git-lfs; \
-    tar -Csrc/git-lfs -zxf ${DOCKER_LFS_BUILD_VERSION}.tar.gz; \
-    cd /tmp/docker_setup/src/git-lfs/rpm; \
-    touch build.log; \
-    tail -f build.log & ./build_rpms.bsh; \
-    rm -rf /tmp/docker_setup
-
 #Add the simple build repo script
 COPY centos_script.bsh /tmp/
 

--- a/centos_7.Dockerfile
+++ b/centos_7.Dockerfile
@@ -24,25 +24,6 @@ RUN cd /usr/local && \
     ln -s /usr/local/go/bin/go /usr/bin/go && \
     ln -s /usr/local/go/bin/gofmt /usr/bin/gofmt
 
-#The purpose of this is to build and install everything needed to build git-lfs
-#Next time. So that the LONG build/installed in centos are only done once, and
-#stored in the image.
-
-#Set to master if you want the latest, but IF there is a failure,
-#the docker will not build, so I decided to make a stable version the default
-ARG DOCKER_LFS_BUILD_VERSION=release-2.4
-
-ADD https://github.com/git-lfs/git-lfs/archive/${DOCKER_LFS_BUILD_VERSION}.tar.gz /tmp/docker_setup/
-RUN cd /tmp/docker_setup/; \
-    mkdir -p src; \
-    cd src; \
-    tar -zxf ../${DOCKER_LFS_BUILD_VERSION}.tar.gz; \
-    mv git-lfs-${DOCKER_LFS_BUILD_VERSION} git-lfs; \
-    cd /tmp/docker_setup/src/git-lfs/rpm; \
-    touch build.log; \
-    tail -f build.log & ./build_rpms.bsh; \
-    rm -rf /tmp/docker_setup
-
 #Add the simple build repo script
 COPY centos_script.bsh /tmp/
 


### PR DESCRIPTION
We build with the Docker containers primarily on Actions these days, where the containers are created new each time.  Building Git LFS during the setup stage means that we must run the entire build and testsuite for a container which will only be used once, which is very expensive.

Remove the code which builds during the setup stage of the Docker containers to make the process faster.
