### PR TITLE
Check hashes of downloaded archives

### DIFF
--- a/build_dockers.bsh
+++ b/build_dockers.bsh
@@ -12,7 +12,8 @@ set -eu
 CUR_DIR=$(dirname "${BASH_SOURCE[0]}")
 
 : ${GOLANG_VERSION:=1.13.4}
-export GOLANG_VERSION
+: ${GOLANG_SHA256:=692d17071736f74be04a72a06dab9cac1cd759377bd85316e52b2227604c004c}
+export GOLANG_VERSION GOLANG_SHA256
 
 #If you are not in docker group and you have sudo, default value is sudo
 : ${SUDO=`if ( [ ! -w /var/run/docker.sock ] && id -nG | grep -qwv docker && [ "${DOCKER_HOST:+dh}" != "dh" ] ) && which sudo > /dev/null 2>&1; then echo sudo; fi`}
@@ -37,9 +38,9 @@ for IMAGE_NAME in "${IMAGE_NAMES[@]}"; do
   pushd $IMAGE_DIR
     echo Docker building ${NAME}
     if [[ $IMAGE_NAME == centos* ]]; then
-      $SUDO docker build --build-arg=GOLANG_VERSION=${GOLANG_VERSION} --build-arg=DOCKER_LFS_BUILD_VERSION=${DOCKER_LFS_BUILD_VERSION} -t gitlfs/build-dockers:${NAME} -f "$NAME.Dockerfile" .
+      $SUDO docker build --build-arg=GOLANG_VERSION=${GOLANG_VERSION} --build-arg=GOLANG_SHA256=${GOLANG_SHA256} --build-arg=DOCKER_LFS_BUILD_VERSION=${DOCKER_LFS_BUILD_VERSION} -t gitlfs/build-dockers:${NAME} -f "$NAME.Dockerfile" .
     else
-      $SUDO docker build --build-arg=GOLANG_VERSION=${GOLANG_VERSION} -t gitlfs/build-dockers:${NAME} -f "$NAME.Dockerfile" .
+      $SUDO docker build --build-arg=GOLANG_VERSION=${GOLANG_VERSION} --build-arg=GOLANG_SHA256=${GOLANG_SHA256} -t gitlfs/build-dockers:${NAME} -f "$NAME.Dockerfile" .
     fi
   popd
 done

--- a/build_dockers.bsh
+++ b/build_dockers.bsh
@@ -11,7 +11,7 @@ set -eu
 
 CUR_DIR=$(dirname "${BASH_SOURCE[0]}")
 
-: ${GOLANG_VERSION:=1.13.1}
+: ${GOLANG_VERSION:=1.13.4}
 export GOLANG_VERSION
 
 #If you are not in docker group and you have sudo, default value is sudo

--- a/centos_6.Dockerfile
+++ b/centos_6.Dockerfile
@@ -4,9 +4,12 @@ MAINTAINER Andy Neff <andyneff@users.noreply.github.com>
 #Docker RUN example, pass in the git-lfs checkout copy you are working with
 LABEL RUN="docker run -v git-lfs-repo-dir:/src -v repo_dir:/repo"
 
+ENV GIT_SHA256=fd0197819920a62f4bb62fe1c4b1e1ead425659edff30ff76ff1b14a5919631c
+
 RUN yum install -y epel-release rsync tar
 RUN yum install -y gcc libcurl-devel gettext-devel openssl-devel perl-CPAN perl-devel zlib-devel make wget autoconf && \
-  wget https://github.com/git/git/archive/v2.16.0.tar.gz -O git.tar.gz && \
+  wget https://mirrors.edge.kernel.org/pub/software/scm/git/git-2.16.0.tar.gz -O git.tar.gz && \
+  [ "$(sha256sum git.tar.gz | cut -d' ' -f1)" = "${GIT_SHA256}" ] && \
   tar -zxf git.tar.gz && \
   cd git-* && \
   make configure && \

--- a/centos_6.Dockerfile
+++ b/centos_6.Dockerfile
@@ -14,7 +14,7 @@ RUN yum install -y gcc libcurl-devel gettext-devel openssl-devel perl-CPAN perl-
   make install && \
   git --version
 
-ARG GOLANG_VERSION=1.13.1
+ARG GOLANG_VERSION=1.13.4
 
 ENV GOROOT=/usr/local/go
 

--- a/centos_6.Dockerfile
+++ b/centos_6.Dockerfile
@@ -15,11 +15,13 @@ RUN yum install -y gcc libcurl-devel gettext-devel openssl-devel perl-CPAN perl-
   git --version
 
 ARG GOLANG_VERSION=1.13.4
+ARG GOLANG_SHA256=692d17071736f74be04a72a06dab9cac1cd759377bd85316e52b2227604c004c
 
 ENV GOROOT=/usr/local/go
 
 RUN cd /usr/local && \
     curl -L -O https://storage.googleapis.com/golang/go${GOLANG_VERSION}.linux-amd64.tar.gz && \
+    [ "$(sha256sum go${GOLANG_VERSION}.linux-amd64.tar.gz | cut -d' ' -f1)" = "${GOLANG_SHA256}" ] && \
     tar zxf go${GOLANG_VERSION}.linux-amd64.tar.gz && \
     ln -s /usr/local/go/bin/go /usr/bin/go && \
     ln -s /usr/local/go/bin/gofmt /usr/bin/gofmt

--- a/centos_7.Dockerfile
+++ b/centos_7.Dockerfile
@@ -15,11 +15,13 @@ RUN yum install -y gettext-devel libcurl-devel openssl-devel perl-CPAN perl-deve
   git --version
 
 ARG GOLANG_VERSION=1.13.4
+ARG GOLANG_SHA256=692d17071736f74be04a72a06dab9cac1cd759377bd85316e52b2227604c004c
 
 ENV GOROOT=/usr/local/go
 
 RUN cd /usr/local && \
     curl -L -O https://storage.googleapis.com/golang/go${GOLANG_VERSION}.linux-amd64.tar.gz && \
+    [ "$(sha256sum go${GOLANG_VERSION}.linux-amd64.tar.gz | cut -d' ' -f1)" = "${GOLANG_SHA256}" ] && \
     tar zxf go${GOLANG_VERSION}.linux-amd64.tar.gz && \
     ln -s /usr/local/go/bin/go /usr/bin/go && \
     ln -s /usr/local/go/bin/gofmt /usr/bin/gofmt

--- a/centos_7.Dockerfile
+++ b/centos_7.Dockerfile
@@ -4,9 +4,12 @@ MAINTAINER Andy Neff <andyneff@users.noreply.github.com>
 #Docker RUN example, pass in the git-lfs checkout copy you are working with
 LABEL RUN="docker run -v git-lfs-repo-dir:/src -v repo_dir:/repo"
 
+ENV GIT_SHA256=fd0197819920a62f4bb62fe1c4b1e1ead425659edff30ff76ff1b14a5919631c
+
 RUN yum install -y rsync ruby ruby-devel gcc
 RUN yum install -y gettext-devel libcurl-devel openssl-devel perl-CPAN perl-devel zlib-devel make wget autoconf && \
-  wget https://github.com/git/git/archive/v2.16.0.tar.gz -O git.tar.gz && \
+  wget https://mirrors.edge.kernel.org/pub/software/scm/git/git-2.16.0.tar.gz -O git.tar.gz && \
+  [ "$(sha256sum git.tar.gz | cut -d' ' -f1)" = "${GIT_SHA256}" ] && \
   tar -zxf git.tar.gz && \
   cd git-* && \
   make configure && \

--- a/centos_7.Dockerfile
+++ b/centos_7.Dockerfile
@@ -14,7 +14,7 @@ RUN yum install -y gettext-devel libcurl-devel openssl-devel perl-CPAN perl-deve
   make install && \
   git --version
 
-ARG GOLANG_VERSION=1.13.1
+ARG GOLANG_VERSION=1.13.4
 
 ENV GOROOT=/usr/local/go
 

--- a/centos_8.Dockerfile
+++ b/centos_8.Dockerfile
@@ -4,11 +4,13 @@ RUN yum install -y rsync ruby ruby-devel gcc
 RUN yum install -y gettext-devel libcurl-devel openssl-devel perl-CPAN perl-devel zlib-devel make wget autoconf git
 
 ARG GOLANG_VERSION=1.13.4
+ARG GOLANG_SHA256=692d17071736f74be04a72a06dab9cac1cd759377bd85316e52b2227604c004c
 
 ENV GOROOT=/usr/local/go
 
 RUN cd /usr/local && \
     curl -L -O https://storage.googleapis.com/golang/go${GOLANG_VERSION}.linux-amd64.tar.gz && \
+    [ "$(sha256sum go${GOLANG_VERSION}.linux-amd64.tar.gz | cut -d' ' -f1)" = "${GOLANG_SHA256}" ] && \
     tar zxf go${GOLANG_VERSION}.linux-amd64.tar.gz && \
     ln -s /usr/local/go/bin/go /usr/bin/go && \
     ln -s /usr/local/go/bin/gofmt /usr/bin/gofmt

--- a/centos_8.Dockerfile
+++ b/centos_8.Dockerfile
@@ -3,7 +3,7 @@ FROM centos:8
 RUN yum install -y rsync ruby ruby-devel gcc
 RUN yum install -y gettext-devel libcurl-devel openssl-devel perl-CPAN perl-devel zlib-devel make wget autoconf git
 
-ARG GOLANG_VERSION=1.13.1
+ARG GOLANG_VERSION=1.13.4
 
 ENV GOROOT=/usr/local/go
 

--- a/debian_10.Dockerfile
+++ b/debian_10.Dockerfile
@@ -7,11 +7,13 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -y update && \
 apt-get install -y git dpkg-dev dh-golang ruby-ronn ronn curl
 
 ARG GOLANG_VERSION=1.13.4
+ARG GOLANG_SHA256=692d17071736f74be04a72a06dab9cac1cd759377bd85316e52b2227604c004c
 
 ENV GOROOT=/usr/local/go
 
 RUN cd /usr/local && \
     curl -L -O https://storage.googleapis.com/golang/go${GOLANG_VERSION}.linux-amd64.tar.gz && \
+    [ "$(sha256sum go${GOLANG_VERSION}.linux-amd64.tar.gz | cut -d' ' -f1)" = "${GOLANG_SHA256}" ] && \
     tar zxf go${GOLANG_VERSION}.linux-amd64.tar.gz && \
     ln -s /usr/local/go/bin/go /usr/bin/go && \
     ln -s /usr/local/go/bin/gofmt /usr/bin/gofmt

--- a/debian_10.Dockerfile
+++ b/debian_10.Dockerfile
@@ -6,7 +6,7 @@ LABEL RUN="docker run -v git-lfs-checkout-dir:/src -v repo_dir:/repo"
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y update && \
 apt-get install -y git dpkg-dev dh-golang ruby-ronn ronn curl
 
-ARG GOLANG_VERSION=1.13.1
+ARG GOLANG_VERSION=1.13.4
 
 ENV GOROOT=/usr/local/go
 

--- a/debian_8.Dockerfile
+++ b/debian_8.Dockerfile
@@ -7,7 +7,7 @@ LABEL RUN="docker run -v git-lfs-checkout-dir:/src -v repo_dir:/repo"
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y update && \
 apt-get install -y git dpkg-dev dh-golang ruby-ronn curl
 
-ARG GOLANG_VERSION=1.13.1
+ARG GOLANG_VERSION=1.13.4
 
 ENV GOROOT=/usr/local/go
 

--- a/debian_8.Dockerfile
+++ b/debian_8.Dockerfile
@@ -8,11 +8,13 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -y update && \
 apt-get install -y git dpkg-dev dh-golang ruby-ronn curl
 
 ARG GOLANG_VERSION=1.13.4
+ARG GOLANG_SHA256=692d17071736f74be04a72a06dab9cac1cd759377bd85316e52b2227604c004c
 
 ENV GOROOT=/usr/local/go
 
 RUN cd /usr/local && \
     curl -L -O https://storage.googleapis.com/golang/go${GOLANG_VERSION}.linux-amd64.tar.gz && \
+    [ "$(sha256sum go${GOLANG_VERSION}.linux-amd64.tar.gz | cut -d' ' -f1)" = "${GOLANG_SHA256}" ] && \
     tar zxf go${GOLANG_VERSION}.linux-amd64.tar.gz && \
     ln -s /usr/local/go/bin/go /usr/bin/go && \
     ln -s /usr/local/go/bin/gofmt /usr/bin/gofmt

--- a/debian_9.Dockerfile
+++ b/debian_9.Dockerfile
@@ -7,7 +7,7 @@ LABEL RUN="docker run -v git-lfs-checkout-dir:/src -v repo_dir:/repo"
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y update && \
 apt-get install -y git dpkg-dev dh-golang ruby-ronn curl
 
-ARG GOLANG_VERSION=1.13.1
+ARG GOLANG_VERSION=1.13.4
 
 ENV GOROOT=/usr/local/go
 

--- a/debian_9.Dockerfile
+++ b/debian_9.Dockerfile
@@ -8,11 +8,13 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -y update && \
 apt-get install -y git dpkg-dev dh-golang ruby-ronn curl
 
 ARG GOLANG_VERSION=1.13.4
+ARG GOLANG_SHA256=692d17071736f74be04a72a06dab9cac1cd759377bd85316e52b2227604c004c
 
 ENV GOROOT=/usr/local/go
 
 RUN cd /usr/local && \
     curl -L -O https://storage.googleapis.com/golang/go${GOLANG_VERSION}.linux-amd64.tar.gz && \
+    [ "$(sha256sum go${GOLANG_VERSION}.linux-amd64.tar.gz | cut -d' ' -f1)" = "${GOLANG_SHA256}" ] && \
     tar zxf go${GOLANG_VERSION}.linux-amd64.tar.gz && \
     ln -s /usr/local/go/bin/go /usr/bin/go && \
     ln -s /usr/local/go/bin/gofmt /usr/bin/gofmt


### PR DESCRIPTION
Right now, we download archives from the Internet into our container and then essentially execute their code.  While the downloads happen over HTTPS, this isn't the greatest idea from a security perspective, especially if we're then using the result to build software we're distributing.

This series adds some changes to the Dockerfiles and scripts to check the hashes of the archives we download.  The hashes provided either come from the Go release page or the signed archives provided by the kernel.org autosigner, as appropriate.

I've tested that the entire Git LFS package build process completes after running building Docker containers using this series.