### PR TITLE
build_dockers: add a -j option to parallelize

### DIFF
--- a/build_dockers.bsh
+++ b/build_dockers.bsh
@@ -17,8 +17,15 @@ export GOLANG_VERSION GOLANG_SHA256
 
 #If you are not in docker group and you have sudo, default value is sudo
 : ${SUDO=`if ( [ ! -w /var/run/docker.sock ] && id -nG | grep -qwv docker && [ "${DOCKER_HOST:+dh}" != "dh" ] ) && which sudo > /dev/null 2>&1; then echo sudo; fi`}
+export SUDO
 
 export DOCKER_LFS_BUILD_VERSION=${DOCKER_LFS_BUILD_VERSION:-release-2.4}
+
+PARALLEL=
+if [[ ${1:-} = -j ]]; then
+  PARALLEL=t
+  shift
+fi
 
 if [[ $# == 0 ]]; then
   IMAGE_NAMES=($(ls -d ${CUR_DIR}/*.Dockerfile))
@@ -27,20 +34,10 @@ else
 fi
 
 #This will take a long time the first time
-for IMAGE_NAME in "${IMAGE_NAMES[@]}"; do
-  # IMAGE_NAME is "./debian_7.Dockerfile"
-  # strip basename
-  # strip leading "./"
-  # strip trailing ".Dockerfile"
-  IMAGE_DIR=$(dirname ${IMAGE_NAME})
-  NAME="$(printf $IMAGE_NAME | sed 's/\.\///' | sed 's/\.Dockerfile$//')"
-
-  pushd $IMAGE_DIR
-    echo Docker building ${NAME}
-    if [[ $IMAGE_NAME == centos* ]]; then
-      $SUDO docker build --build-arg=GOLANG_VERSION=${GOLANG_VERSION} --build-arg=GOLANG_SHA256=${GOLANG_SHA256} --build-arg=DOCKER_LFS_BUILD_VERSION=${DOCKER_LFS_BUILD_VERSION} -t gitlfs/build-dockers:${NAME} -f "$NAME.Dockerfile" .
-    else
-      $SUDO docker build --build-arg=GOLANG_VERSION=${GOLANG_VERSION} --build-arg=GOLANG_SHA256=${GOLANG_SHA256} -t gitlfs/build-dockers:${NAME} -f "$NAME.Dockerfile" .
-    fi
-  popd
-done
+if [[ -n $PARALLEL ]]; then
+  printf "%s\n" ${IMAGE_NAMES[@]} | parallel --line-buffer -I{} "$CUR_DIR/build_one" {}
+else
+  for IMAGE_NAME in "${IMAGE_NAMES[@]}"; do
+    "$CUR_DIR/build_one" "$IMAGE_NAME"
+  done
+fi

--- a/build_one
+++ b/build_one
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -e
+
+IMAGE_NAME="$1"
+
+# IMAGE_NAME is "./debian_7.Dockerfile"
+# strip basename
+# strip leading "./"
+# strip trailing ".Dockerfile"
+IMAGE_DIR=$(dirname ${IMAGE_NAME})
+NAME="$(printf $IMAGE_NAME | sed 's/\.\///' | sed 's/\.Dockerfile$//')"
+
+cd $IMAGE_DIR
+echo Docker building ${NAME}
+if [[ $IMAGE_NAME == centos* ]]; then
+  $SUDO docker build --build-arg=GOLANG_VERSION=${GOLANG_VERSION} --build-arg=GOLANG_SHA256=${GOLANG_SHA256} --build-arg=DOCKER_LFS_BUILD_VERSION=${DOCKER_LFS_BUILD_VERSION} -t gitlfs/build-dockers:${NAME} -f "$NAME.Dockerfile" .
+else
+  $SUDO docker build --build-arg=GOLANG_VERSION=${GOLANG_VERSION} --build-arg=GOLANG_SHA256=${GOLANG_SHA256} -t gitlfs/build-dockers:${NAME} -f "$NAME.Dockerfile" .
+fi


### PR DESCRIPTION
Currently, building our Docker containers sequentially takes about 14 minutes from a fresh image on a reasonably fast connection.  This expense must be incurred every time we run a new CI job.

To counter this, let's teach build_dockers.bsh a command to run things in parallel using GNU parallel.  The command works very similarly to xargs, and we can continue to default to running things in serial if the user doesn't specify the -j option. In order to make this possible, move the actual build process for a single image into a separate script so it's easy to run from parallel.

Note that before this change, the job took 14 minutes on a MacBook Pro 2018 running Linux; afterwards, it takes 6.  The improvements in CI will be less noticeable since we have fewer processors, but should still be nontrivial.

Also note that `build_dockers.bsh` runs with `set -eu`, hence the need to initialize all variables.