### PR TITLE
Update to Go 1.16.2

### DIFF
--- a/build_dockers.bsh
+++ b/build_dockers.bsh
@@ -11,8 +11,8 @@ set -eu
 
 CUR_DIR=$(dirname "${BASH_SOURCE[0]}")
 
-: ${GOLANG_VERSION:=1.15.5}
-: ${GOLANG_SHA256:=9a58494e8da722c3aef248c9227b0e9c528c7318309827780f16220998180a0d}
+: ${GOLANG_VERSION:=1.16.2}
+: ${GOLANG_SHA256:=542e936b19542e62679766194364f45141fde55169db2d8d01046555ca9eb4b8}
 export GOLANG_VERSION GOLANG_SHA256
 
 #If you are not in docker group and you have sudo, default value is sudo

--- a/centos_7.Dockerfile
+++ b/centos_7.Dockerfile
@@ -17,8 +17,8 @@ RUN yum install -y gettext-devel libcurl-devel openssl-devel perl-CPAN perl-deve
   make install && \
   git --version
 
-ARG GOLANG_VERSION=1.15.5
-ARG GOLANG_SHA256=9a58494e8da722c3aef248c9227b0e9c528c7318309827780f16220998180a0d
+ARG GOLANG_VERSION=1.16.2
+ARG GOLANG_SHA256=542e936b19542e62679766194364f45141fde55169db2d8d01046555ca9eb4b8
 
 ENV GOROOT=/usr/local/go
 

--- a/centos_8.Dockerfile
+++ b/centos_8.Dockerfile
@@ -3,8 +3,8 @@ FROM centos:8
 RUN yum install -y rsync ruby ruby-devel gcc
 RUN yum install -y gettext-devel libcurl-devel openssl-devel perl-CPAN perl-devel zlib-devel make wget autoconf git
 
-ARG GOLANG_VERSION=1.15.5
-ARG GOLANG_SHA256=9a58494e8da722c3aef248c9227b0e9c528c7318309827780f16220998180a0d
+ARG GOLANG_VERSION=1.16.2
+ARG GOLANG_SHA256=542e936b19542e62679766194364f45141fde55169db2d8d01046555ca9eb4b8
 
 ENV GOROOT=/usr/local/go
 

--- a/debian_10.Dockerfile
+++ b/debian_10.Dockerfile
@@ -6,8 +6,8 @@ LABEL RUN="docker run -v git-lfs-checkout-dir:/src -v repo_dir:/repo"
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y update && \
 apt-get install -y git dpkg-dev dh-golang ruby-ronn ronn curl
 
-ARG GOLANG_VERSION=1.15.5
-ARG GOLANG_SHA256=9a58494e8da722c3aef248c9227b0e9c528c7318309827780f16220998180a0d
+ARG GOLANG_VERSION=1.16.2
+ARG GOLANG_SHA256=542e936b19542e62679766194364f45141fde55169db2d8d01046555ca9eb4b8
 
 ENV GOROOT=/usr/local/go
 

--- a/debian_9.Dockerfile
+++ b/debian_9.Dockerfile
@@ -7,8 +7,8 @@ LABEL RUN="docker run -v git-lfs-checkout-dir:/src -v repo_dir:/repo"
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y update && \
 apt-get install -y git dpkg-dev dh-golang ruby-ronn curl
 
-ARG GOLANG_VERSION=1.15.5
-ARG GOLANG_SHA256=9a58494e8da722c3aef248c9227b0e9c528c7318309827780f16220998180a0d
+ARG GOLANG_VERSION=1.16.2
+ARG GOLANG_SHA256=542e936b19542e62679766194364f45141fde55169db2d8d01046555ca9eb4b8
 
 ENV GOROOT=/usr/local/go
 


### PR DESCRIPTION
Update to the latest version of Go, 1.16.2.