### PR TITLE
debian: install packages for building with cgo on i686

### DIFF
--- a/debian_11.Dockerfile
+++ b/debian_11.Dockerfile
@@ -3,8 +3,10 @@ FROM debian:bullseye
 #Docker RUN example, pass in the git-lfs checkout copy you are working with
 LABEL RUN="docker run -v git-lfs-checkout-dir:/src -v repo_dir:/repo"
 
+RUN dpkg --add-architecture i386
+
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y update && \
-apt-get install -y git dpkg-dev dh-golang ruby-ronn ronn curl
+apt-get install -y --no-install-recommends git dpkg-dev dh-golang ruby-ronn ronn curl build-essential gcc-i686-linux-gnu libc6-dev:i386
 
 ARG GOLANG_VERSION=1.17
 ARG GOLANG_SHA256=6bf89fc4f5ad763871cf7eac80a2d594492de7a818303283f1366a7f6a30372d


### PR DESCRIPTION
In CI, we build our Debian packages with cgo enabled.  In order to do so successfully, we need a compiler for i686 and the shared libraries from the Debian i386 architecture in order so that dpkg-shlibdeps can specify the proper dependencies.  Let's install these packages in order to make it possible to build our i386 packages in the same container as amd64.
