### PR TITLE
CentOS: run yum upgrade before continuing

### DIFF
--- a/centos_7.Dockerfile
+++ b/centos_7.Dockerfile
@@ -6,6 +6,7 @@ LABEL RUN="docker run -v git-lfs-repo-dir:/src -v repo_dir:/repo"
 
 ENV GIT_SHA256=fd0197819920a62f4bb62fe1c4b1e1ead425659edff30ff76ff1b14a5919631c
 
+RUN yum -y upgrade
 RUN yum install -y rsync ruby ruby-devel gcc
 RUN yum install -y gettext-devel libcurl-devel openssl-devel perl-CPAN perl-devel zlib-devel make wget autoconf && \
   wget https://mirrors.edge.kernel.org/pub/software/scm/git/git-2.16.0.tar.gz -O git.tar.gz && \

--- a/centos_8.Dockerfile
+++ b/centos_8.Dockerfile
@@ -1,5 +1,6 @@
 FROM centos:8
 
+RUN yum -y upgrade
 RUN yum install -y rsync ruby ruby-devel gcc
 RUN yum install -y gettext-devel libcurl-devel openssl-devel perl-CPAN perl-devel zlib-devel make wget autoconf git
 


### PR DESCRIPTION
Due to the expiration of DST Root CA X3, CentOS 7 needs an upgrade to its ca-certificates package to remove this CA so that it can resolve sites using Let's Encrypt certificates, such as kernel.org, since its version of OpenSSL is too old to automatically find a trusted path. Since we use kernel.org to get the Git tarball to replace the obsolete version shipped in CentOS 7, this is required for our Docker builds to work there.

Let's make sure our CentOS containers run yum upgrade before installing other packages so that we have a fully functional, secure system as a baseline.
