### PR TITLE
build_dockers: avoid using unset variable

### DIFF
--- a/build_dockers.bsh
+++ b/build_dockers.bsh
@@ -12,7 +12,7 @@ set -eu
 CUR_DIR=$(dirname "${BASH_SOURCE[0]}")
 
 GOLANG_ARCH="amd64"
-while [ -n "$1" ]
+while [ -n "${1-}" ]
 do
   case "$1" in
     --arch=*)


### PR DESCRIPTION
In our while loop to parse options, we can end up using $1 when it's unset if we don't pass any arguments.  Fix this by using a default value if the variable is unset.
