### PR TITLE
Switch to Rocky Linux

### DIFF
--- a/centos_8.Dockerfile
+++ b/centos_8.Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:8
+FROM rockylinux/rockylinux:8
 
 RUN yum -y upgrade
 RUN yum install -y rsync ruby ruby-devel rubygems-devel gcc

--- a/centos_8.Dockerfile
+++ b/centos_8.Dockerfile
@@ -1,7 +1,7 @@
 FROM centos:8
 
 RUN yum -y upgrade
-RUN yum install -y rsync ruby ruby-devel gcc
+RUN yum install -y rsync ruby ruby-devel rubygems-devel gcc
 RUN yum install -y gettext-devel libcurl-devel openssl-devel perl-CPAN perl-devel zlib-devel make wget autoconf git
 
 ARG GOLANG_VERSION=1.17.2


### PR DESCRIPTION
At the end of 2021, CentOS 8 is going EOL.  Let's switch to Rocky Linux, which is the similarly based around a rebuild of RHEL 8.  We keep the "centos_8" name because it avoids a lot of needless changes to various repositories.

Closes git-lfs/git-lfs#4680
