### PR TITLE
debian: include gettext

### DIFF
--- a/debian_10.Dockerfile
+++ b/debian_10.Dockerfile
@@ -4,7 +4,7 @@ FROM debian:buster
 LABEL RUN="docker run -v git-lfs-checkout-dir:/src -v repo_dir:/repo"
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y update && \
-apt-get install -y git dpkg-dev dh-golang ruby-ronn ronn curl
+apt-get install -y gettext git dpkg-dev dh-golang ruby-ronn ronn curl
 
 ARG GOLANG_VERSION=1.17.2
 ARG GOLANG_SHA256=f242a9db6a0ad1846de7b6d94d507915d14062660616a61ef7c808a76e4f1676

--- a/debian_11.Dockerfile
+++ b/debian_11.Dockerfile
@@ -6,7 +6,7 @@ LABEL RUN="docker run -v git-lfs-checkout-dir:/src -v repo_dir:/repo"
 RUN dpkg --add-architecture i386
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y update && \
-apt-get install -y --no-install-recommends git dpkg-dev dh-golang ruby-ronn ronn curl build-essential gcc-i686-linux-gnu libc6-dev:i386
+apt-get install -y --no-install-recommends gettext git dpkg-dev dh-golang ruby-ronn ronn curl build-essential gcc-i686-linux-gnu libc6-dev:i386
 
 ARG GOLANG_VERSION=1.17.2
 ARG GOLANG_SHA256=f242a9db6a0ad1846de7b6d94d507915d14062660616a61ef7c808a76e4f1676

--- a/debian_9.Dockerfile
+++ b/debian_9.Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER Andy Neff <andyneff@users.noreply.github.com>
 LABEL RUN="docker run -v git-lfs-checkout-dir:/src -v repo_dir:/repo"
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y update && \
-apt-get install -y git dpkg-dev dh-golang ruby-ronn curl
+apt-get install -y gettext git dpkg-dev dh-golang ruby-ronn curl
 
 ARG GOLANG_VERSION=1.17.2
 ARG GOLANG_SHA256=f242a9db6a0ad1846de7b6d94d507915d14062660616a61ef7c808a76e4f1676


### PR DESCRIPTION
In the future, we'll need gettext for building Debian packages.  Let's make sure to include it in our containers.