### PR TITLE
Update Dockerfiles to allow building with Asciidoctor

### DIFF
--- a/centos_7.Dockerfile
+++ b/centos_7.Dockerfile
@@ -7,7 +7,8 @@ LABEL RUN="docker run -v git-lfs-repo-dir:/src -v repo_dir:/repo"
 ENV GIT_SHA256=fd0197819920a62f4bb62fe1c4b1e1ead425659edff30ff76ff1b14a5919631c
 
 RUN yum -y upgrade
-RUN yum install -y rsync ruby ruby-devel gcc
+RUN yum install -y centos-release-scl
+RUN yum install -y rsync rh-ruby30-ruby rh-ruby30-build gcc
 RUN yum install -y gettext-devel libcurl-devel openssl-devel perl-CPAN perl-devel zlib-devel make wget autoconf && \
   wget https://mirrors.edge.kernel.org/pub/software/scm/git/git-2.16.0.tar.gz -O git.tar.gz && \
   [ "$(sha256sum git.tar.gz | cut -d' ' -f1)" = "${GIT_SHA256}" ] && \
@@ -34,4 +35,4 @@ RUN cd /usr/local && \
 #Add the simple build repo script
 COPY centos_script.bsh /tmp/
 
-CMD /tmp/centos_script.bsh
+CMD scl enable rh-ruby30 /tmp/centos_script.bsh

--- a/debian_10.Dockerfile
+++ b/debian_10.Dockerfile
@@ -4,7 +4,7 @@ FROM debian:buster
 LABEL RUN="docker run -v git-lfs-checkout-dir:/src -v repo_dir:/repo"
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y update && \
-apt-get install -y gettext git dpkg-dev dh-golang ruby-ronn ronn curl
+apt-get install -y gettext git dpkg-dev dh-golang ruby-ronn ronn asciidoctor curl
 
 ARG GOLANG_VERSION=1.18.2
 ARG GOLANG_SHA256=e54bec97a1a5d230fc2f9ad0880fcbabb5888f30ed9666eca4a91c5a32e86cbc

--- a/debian_11.Dockerfile
+++ b/debian_11.Dockerfile
@@ -6,7 +6,7 @@ LABEL RUN="docker run -v git-lfs-checkout-dir:/src -v repo_dir:/repo"
 RUN dpkg --add-architecture i386
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y update && \
-apt-get install -y --no-install-recommends gettext git dpkg-dev dh-golang ruby-ronn ronn curl build-essential gcc-i686-linux-gnu libc6-dev:i386
+apt-get install -y --no-install-recommends gettext git dpkg-dev dh-golang ruby-ronn ronn asciidoctor curl build-essential gcc-i686-linux-gnu libc6-dev:i386
 
 ARG GOLANG_VERSION=1.18.2
 ARG GOLANG_SHA256=e54bec97a1a5d230fc2f9ad0880fcbabb5888f30ed9666eca4a91c5a32e86cbc

--- a/debian_9.Dockerfile
+++ b/debian_9.Dockerfile
@@ -5,7 +5,7 @@ MAINTAINER Andy Neff <andyneff@users.noreply.github.com>
 LABEL RUN="docker run -v git-lfs-checkout-dir:/src -v repo_dir:/repo"
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y update && \
-apt-get install -y gettext git dpkg-dev dh-golang ruby-ronn curl
+apt-get install -y gettext git dpkg-dev dh-golang ruby-ronn asciidoctor curl
 
 ARG GOLANG_VERSION=1.18.2
 ARG GOLANG_SHA256=e54bec97a1a5d230fc2f9ad0880fcbabb5888f30ed9666eca4a91c5a32e86cbc


### PR DESCRIPTION
Update the Dockerfiles to allow building with Asciidoctor.  Note that we don't remove the use of ronn in the Debian Dockerfiles to prevent CI from failing before the git-lfs/git-lfs changes are merged.