### PR TITLE
Run `make vendor` in Debian

### DIFF
--- a/debian_script.bsh
+++ b/debian_script.bsh
@@ -20,6 +20,7 @@ process_architecture () {
   cd "${GIT_LFS_BUILD_DIR}/$arch"
   git clean -xdf .
   git checkout-index --force --all
+  make vendor
   dpkg-buildpackage -d -us -uc -b -a"$arch"
 }
 


### PR DESCRIPTION
We're going to stop vendoring dependencies in the Git LFS repository. However, Debian configures the Go binary not to download data from the Internet during the package build, which obviously means that dependencies are not satisfied.

To avoid a problem, run `make vendor` to download appropriate dependencies before the build so that the build process continues to work.