### PR TITLE
Add a Dockerfile for Rocky Linux 9

### DIFF
--- a/rocky_9.Dockerfile
+++ b/rocky_9.Dockerfile
@@ -1,0 +1,22 @@
+FROM rockylinux/rockylinux:9
+
+RUN yum -y upgrade
+RUN yum install -y rsync ruby ruby-devel rubygems-devel gcc
+RUN yum install -y gettext-devel libcurl-devel openssl-devel perl-CPAN perl-devel zlib-devel make wget autoconf git
+
+ARG GOLANG_VERSION=1.18.2
+ARG GOLANG_SHA256=e54bec97a1a5d230fc2f9ad0880fcbabb5888f30ed9666eca4a91c5a32e86cbc
+ARG GOLANG_ARCH=amd64
+
+ENV GOROOT=/usr/local/go
+
+RUN cd /usr/local && \
+    curl -L -O https://golang.org/dl/go${GOLANG_VERSION}.linux-amd64.tar.gz && \
+    [ "$(sha256sum go${GOLANG_VERSION}.linux-amd64.tar.gz | cut -d' ' -f1)" = "${GOLANG_SHA256}" ] && \
+    tar zxf go${GOLANG_VERSION}.linux-amd64.tar.gz && \
+    ln -s /usr/local/go/bin/go /usr/bin/go && \
+    ln -s /usr/local/go/bin/gofmt /usr/bin/gofmt
+
+COPY centos_script.bsh /tmp/
+
+CMD /tmp/centos_script.bsh


### PR DESCRIPTION
Now that RHEL 9 is out, let's perform a RHEL 9-equivalent build.  Use Rocky Linux 9 for this purpose, since it's a rebuild of RHEL 9 and doesn't require payment for a license.