### PR TITLE
Bump Go version to 1.19.3

### DIFF
--- a/build_dockers.bsh
+++ b/build_dockers.bsh
@@ -25,13 +25,13 @@ do
   esac
 done
 
-: ${GOLANG_VERSION:=1.18.2}
+: ${GOLANG_VERSION:=1.19.3}
 case "$GOLANG_ARCH" in
   amd64)
-    : ${GOLANG_SHA256:=e54bec97a1a5d230fc2f9ad0880fcbabb5888f30ed9666eca4a91c5a32e86cbc}
+    : ${GOLANG_SHA256:=74b9640724fd4e6bb0ed2a1bc44ae813a03f1e72a4c76253e2d5c015494430ba}
     ;;
   arm64)
-    : ${GOLANG_SHA256:=fc4ad28d0501eaa9c9d6190de3888c9d44d8b5fb02183ce4ae93713f67b8a35b}
+    : ${GOLANG_SHA256:=99de2fe112a52ab748fb175edea64b313a0c8d51d6157dba683a6be163fd5eab}
     ;;
 esac
 export GOLANG_VERSION GOLANG_SHA256 GOLANG_ARCH

--- a/centos_7.Dockerfile
+++ b/centos_7.Dockerfile
@@ -19,8 +19,8 @@ RUN yum install -y gettext-devel libcurl-devel openssl-devel perl-CPAN perl-deve
   make install && \
   git --version
 
-ARG GOLANG_VERSION=1.18.2
-ARG GOLANG_SHA256=e54bec97a1a5d230fc2f9ad0880fcbabb5888f30ed9666eca4a91c5a32e86cbc
+ARG GOLANG_VERSION=1.19.3
+ARG GOLANG_SHA256=74b9640724fd4e6bb0ed2a1bc44ae813a03f1e72a4c76253e2d5c015494430ba
 ARG GOLANG_ARCH=amd64
 
 ENV GOROOT=/usr/local/go

--- a/centos_8.Dockerfile
+++ b/centos_8.Dockerfile
@@ -4,8 +4,8 @@ RUN yum -y upgrade
 RUN yum install -y rsync ruby ruby-devel rubygems-devel gcc
 RUN yum install -y gettext-devel libcurl-devel openssl-devel perl-CPAN perl-devel zlib-devel make wget autoconf git
 
-ARG GOLANG_VERSION=1.18.2
-ARG GOLANG_SHA256=e54bec97a1a5d230fc2f9ad0880fcbabb5888f30ed9666eca4a91c5a32e86cbc
+ARG GOLANG_VERSION=1.19.3
+ARG GOLANG_SHA256=74b9640724fd4e6bb0ed2a1bc44ae813a03f1e72a4c76253e2d5c015494430ba
 ARG GOLANG_ARCH=amd64
 
 ENV GOROOT=/usr/local/go

--- a/debian_10.Dockerfile
+++ b/debian_10.Dockerfile
@@ -6,8 +6,8 @@ LABEL RUN="docker run -v git-lfs-checkout-dir:/src -v repo_dir:/repo"
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y update && \
 apt-get install -y gettext git dpkg-dev dh-golang ruby-ronn ronn asciidoctor curl
 
-ARG GOLANG_VERSION=1.18.2
-ARG GOLANG_SHA256=e54bec97a1a5d230fc2f9ad0880fcbabb5888f30ed9666eca4a91c5a32e86cbc
+ARG GOLANG_VERSION=1.19.3
+ARG GOLANG_SHA256=74b9640724fd4e6bb0ed2a1bc44ae813a03f1e72a4c76253e2d5c015494430ba
 ARG GOLANG_ARCH=amd64
 
 ENV GOROOT=/usr/local/go

--- a/debian_11.Dockerfile
+++ b/debian_11.Dockerfile
@@ -8,8 +8,8 @@ RUN dpkg --add-architecture i386
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y update && \
 apt-get install -y --no-install-recommends gettext git dpkg-dev dh-golang ruby-ronn ronn asciidoctor curl build-essential gcc-i686-linux-gnu libc6-dev:i386
 
-ARG GOLANG_VERSION=1.18.2
-ARG GOLANG_SHA256=e54bec97a1a5d230fc2f9ad0880fcbabb5888f30ed9666eca4a91c5a32e86cbc
+ARG GOLANG_VERSION=1.19.3
+ARG GOLANG_SHA256=74b9640724fd4e6bb0ed2a1bc44ae813a03f1e72a4c76253e2d5c015494430ba
 ARG GOLANG_ARCH=amd64
 
 ENV GOROOT=/usr/local/go

--- a/debian_9.Dockerfile
+++ b/debian_9.Dockerfile
@@ -7,8 +7,8 @@ LABEL RUN="docker run -v git-lfs-checkout-dir:/src -v repo_dir:/repo"
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y update && \
 apt-get install -y gettext git dpkg-dev dh-golang ruby-ronn asciidoctor curl
 
-ARG GOLANG_VERSION=1.18.2
-ARG GOLANG_SHA256=e54bec97a1a5d230fc2f9ad0880fcbabb5888f30ed9666eca4a91c5a32e86cbc
+ARG GOLANG_VERSION=1.19.3
+ARG GOLANG_SHA256=74b9640724fd4e6bb0ed2a1bc44ae813a03f1e72a4c76253e2d5c015494430ba
 ARG GOLANG_ARCH=amd64
 
 ENV GOROOT=/usr/local/go

--- a/rocky_9.Dockerfile
+++ b/rocky_9.Dockerfile
@@ -4,8 +4,8 @@ RUN yum -y upgrade
 RUN yum install -y rsync ruby ruby-devel rubygems-devel gcc
 RUN yum install -y gettext-devel libcurl-devel openssl-devel perl-CPAN perl-devel zlib-devel make wget autoconf git
 
-ARG GOLANG_VERSION=1.18.2
-ARG GOLANG_SHA256=e54bec97a1a5d230fc2f9ad0880fcbabb5888f30ed9666eca4a91c5a32e86cbc
+ARG GOLANG_VERSION=1.19.3
+ARG GOLANG_SHA256=74b9640724fd4e6bb0ed2a1bc44ae813a03f1e72a4c76253e2d5c015494430ba
 ARG GOLANG_ARCH=amd64
 
 ENV GOROOT=/usr/local/go


### PR DESCRIPTION
We want to update to the latest version of Go to get performance and security fixes.  Let's use the `update-hashes` script to update to Go 1.19.3.