### PR TITLE
Rename default branch name to `main` in references and add security and license documentation

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,24 @@
+MIT License
+
+Copyright (c) 2015- GitHub, Inc. and Git LFS contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+Note that Git LFS uses components from other Go modules (included in `vendor/`)
+which are under different licenses.  See those LICENSE files for details.

--- a/README.md
+++ b/README.md
@@ -21,10 +21,10 @@ the docker directory for more information on using these dockers.
 ### Committing tags ###
 
 To make docker tags in the automated build, you have to create a git branch/tag
-and map that to a docker tag. While master is the main development branch for this
+and map that to a docker tag. While `main` is the primary development branch for this
 repo, it did not make sence to branch and update a Dockerfile in different branches.
 Instead, the `commit_tags.bsh` script will execute `docker+` and generate the Dockerfiles
-for each tag and then commit them. This way you develop on master, and when you are ready
+for each tag and then commit them. This way you develop on `main`, and when you are ready
 to releast, run `commit_tags.bsh` and then push the tags. Note, you will have to do a 
 force push to update the tags.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,4 @@
+Please see
+[SECURITY.md](https://github.com/git-lfs/git-lfs/blob/main/SECURITY.md)
+in the main Git LFS repository for information on how to report security
+vulnerabilities in this package.

--- a/trigger.bsh
+++ b/trigger.bsh
@@ -28,7 +28,7 @@ for tag in "${TAG_LIST[@]}"; do
     echo '{
   "commit": "'$(git rev-parse $tag)'",
   "ref": "refs/tags/'$tag'",
-  "default_branch": "master"
+  "default_branch": "main"
 }' | $DRYRUN curl -X POST --data @- -H "Content-Type: application/json" $QUAY_HOOK
   fi
   if [ "$DOCKERHUB_HOOK" != "" -a "$#" -gt "0" ]; then


### PR DESCRIPTION
We rename references to our primary trunk branch to `main` in the expectation that we will rename the branch in the repository before or immediately after merging this commit's PR.

We also add a security policy document which simply references our primary security policy in the `git-lfs/git-lfs` repository, and an MIT license file which matches those of our other projects.