### PR TITLE
Remove `DOCKER_LFS_BUILD_VERSION` environment variable and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,10 +53,6 @@ the next. This is why triggering all is preferred.
 
 `export` before calling `commit_tags.bsh`/`build_docker.bsh`. 
 
-`DOCKER_LFS_BUILD_VERSION` - The version of LFS used to bootstrap the (CentOS)
-environment. This does not need to be bumped every version. This can be a tag 
-or a sha.
-
 ## Old way ## 
 
 1. Build the dockers
@@ -72,15 +68,7 @@ or a sha.
 In order to use the docker **images**, they have to be built so that they are
 ready to be used. For OSes like Debian, this is a fairly quick process. 
 However CentOS takes considerably longer time, since it has to build/install go, ruby,
-or git from source, depending on the version. Fortunately, you can build the 
-docker images JUST once, and you won't have to build it again (until the 
-`DOCKER_LFS_BUILD_VERSION` changes.) The build script uses a downloaded release
-from github of git-lfs to bootstrap the CentOS image and build/install all the 
-necessary software.
-
-This means all the compiling, yum/apt-get/custom dependency compiling is done 
-once and saved. (This is done in CentOS by using the already existing 
-`./rpm/rpm_build.bsh` script to bootstrap the image and saving the image.)
+or git from source, depending on the version.
 
 The script that takes care of ALL of these details for you is
 

--- a/build_dockers.bsh
+++ b/build_dockers.bsh
@@ -3,10 +3,6 @@
 # Usage:
 #  ./build_dockers.bsh - Build all the compiling docker images
 #  ./build_dockers.bsh lfs_centos_5 lfs_centos_7 - Build only CentOS 5 & 7 image
-#
-# Special Environment Variables
-#  DOCKER_LFS_BUILD_VERSION - tag or sha to build envirnment off of. Important
-#                             in CentOS
 set -eu
 
 CUR_DIR=$(dirname "${BASH_SOURCE[0]}")
@@ -39,8 +35,6 @@ export GOLANG_VERSION GOLANG_SHA256 GOLANG_ARCH
 #If you are not in docker group and you have sudo, default value is sudo
 : ${SUDO=`if ( [ ! -w /var/run/docker.sock ] && id -nG | grep -qwv docker && [ "${DOCKER_HOST:+dh}" != "dh" ] ) && which sudo > /dev/null 2>&1; then echo sudo; fi`}
 export SUDO
-
-export DOCKER_LFS_BUILD_VERSION=${DOCKER_LFS_BUILD_VERSION:-release-2.4}
 
 PARALLEL=
 if [[ ${1:-} = -j ]]; then

--- a/build_one
+++ b/build_one
@@ -13,8 +13,4 @@ NAME="$(printf $IMAGE_NAME | sed 's/\.\///' | sed 's/\.Dockerfile$//')"
 
 cd $IMAGE_DIR
 echo Docker building ${NAME}
-if [[ $IMAGE_NAME == centos* ]]; then
-  $SUDO docker build --build-arg=GOLANG_VERSION=${GOLANG_VERSION} --build-arg=GOLANG_SHA256=${GOLANG_SHA256} --build-arg=GOLANG_ARCH=${GOLANG_ARCH} --build-arg=DOCKER_LFS_BUILD_VERSION=${DOCKER_LFS_BUILD_VERSION} --platform "$GOLANG_ARCH" -t gitlfs/build-dockers:${NAME} -f "$NAME.Dockerfile" .
-else
-  $SUDO docker build --build-arg=GOLANG_VERSION=${GOLANG_VERSION} --build-arg=GOLANG_SHA256=${GOLANG_SHA256} --build-arg=GOLANG_ARCH=${GOLANG_ARCH} --platform "$GOLANG_ARCH" -t gitlfs/build-dockers:${NAME} -f "$NAME.Dockerfile" .
-fi
+$SUDO docker build --build-arg=GOLANG_VERSION=${GOLANG_VERSION} --build-arg=GOLANG_SHA256=${GOLANG_SHA256} --build-arg=GOLANG_ARCH=${GOLANG_ARCH} --platform "$GOLANG_ARCH" -t gitlfs/build-dockers:${NAME} -f "$NAME.Dockerfile" .

--- a/commit_tags.bsh
+++ b/commit_tags.bsh
@@ -7,9 +7,6 @@ cd $(dirname "${BASH_SOURCE[0]}")
 : ${GOLANG_VERSION:=1.13.1}
 export GOLANG_VERSION
 
-export DOCKER_LFS_BUILD_VERSION=${DOCKER_LFS_BUILD_VERSION:-release-2.1}
-
-
 if ! git diff --cached --exit-code >/dev/null 2>&1 || ! git diff --exit-code >/dev/null 2>&1; then
   echo "Git repo is not clean. Please make sure everything is checked in and commited"
   exit 2


### PR DESCRIPTION
In commit 330be9d601b234dbc75b4fe68c3a76fd4a7d49e2 of PR #30 we removed the directives from the CentOS Dockerfiles which compiled a version of Git LFS using a stable release version during the container image setup/build stage, as was originally done to save compilation time later when the containers were run.  This was no longer valuable as it increased the overall runtime in GitHub Actions, where we build containers but only use them once, so we removed the directives.

However, we did not remove the supporting references to the `DOCKER_LFS_BUILD_VERSION` environment variable which could be used to set the specific version of the "bootstrapped" Git LFS build, so we remove them now along with the relevant documentation.