### PR TITLE
*.Dockerfile: force use of local Go toolchain

### DIFF
--- a/centos_7.Dockerfile
+++ b/centos_7.Dockerfile
@@ -24,6 +24,7 @@ ARG GOLANG_SHA256=b945ae2bb5db01a0fb4786afde64e6fbab50b67f6fa0eb6cfa4924f16a7ff1
 ARG GOLANG_ARCH=amd64
 
 ENV GOROOT=/usr/local/go
+ENV GOTOOLCHAIN=local
 
 RUN cd /usr/local && \
     curl -L -O https://golang.org/dl/go${GOLANG_VERSION}.linux-amd64.tar.gz && \

--- a/centos_8.Dockerfile
+++ b/centos_8.Dockerfile
@@ -9,6 +9,7 @@ ARG GOLANG_SHA256=b945ae2bb5db01a0fb4786afde64e6fbab50b67f6fa0eb6cfa4924f16a7ff1
 ARG GOLANG_ARCH=amd64
 
 ENV GOROOT=/usr/local/go
+ENV GOTOOLCHAIN=local
 
 RUN cd /usr/local && \
     curl -L -O https://golang.org/dl/go${GOLANG_VERSION}.linux-amd64.tar.gz && \

--- a/debian_10.Dockerfile
+++ b/debian_10.Dockerfile
@@ -11,6 +11,7 @@ ARG GOLANG_SHA256=b945ae2bb5db01a0fb4786afde64e6fbab50b67f6fa0eb6cfa4924f16a7ff1
 ARG GOLANG_ARCH=amd64
 
 ENV GOROOT=/usr/local/go
+ENV GOTOOLCHAIN=local
 
 RUN cd /usr/local && \
     curl -L -O https://golang.org/dl/go${GOLANG_VERSION}.linux-${GOLANG_ARCH}.tar.gz && \

--- a/debian_11.Dockerfile
+++ b/debian_11.Dockerfile
@@ -13,6 +13,7 @@ ARG GOLANG_SHA256=b945ae2bb5db01a0fb4786afde64e6fbab50b67f6fa0eb6cfa4924f16a7ff1
 ARG GOLANG_ARCH=amd64
 
 ENV GOROOT=/usr/local/go
+ENV GOTOOLCHAIN=local
 
 RUN cd /usr/local && \
     curl -L -O https://golang.org/dl/go${GOLANG_VERSION}.linux-${GOLANG_ARCH}.tar.gz && \

--- a/debian_12.Dockerfile
+++ b/debian_12.Dockerfile
@@ -13,6 +13,7 @@ ARG GOLANG_SHA256=b945ae2bb5db01a0fb4786afde64e6fbab50b67f6fa0eb6cfa4924f16a7ff1
 ARG GOLANG_ARCH=amd64
 
 ENV GOROOT=/usr/local/go
+ENV GOTOOLCHAIN=local
 
 RUN cd /usr/local && \
     curl -L -O https://golang.org/dl/go${GOLANG_VERSION}.linux-${GOLANG_ARCH}.tar.gz && \

--- a/rocky_9.Dockerfile
+++ b/rocky_9.Dockerfile
@@ -9,6 +9,7 @@ ARG GOLANG_SHA256=b945ae2bb5db01a0fb4786afde64e6fbab50b67f6fa0eb6cfa4924f16a7ff1
 ARG GOLANG_ARCH=amd64
 
 ENV GOROOT=/usr/local/go
+ENV GOTOOLCHAIN=local
 
 RUN cd /usr/local && \
     curl -L -O https://golang.org/dl/go${GOLANG_VERSION}.linux-amd64.tar.gz && \


### PR DESCRIPTION
Since commit 99652c393fcbd8b3b1da33eacd7230da8d00cc4f in PR #31 our Dockerfiles verify the SHA-256 hash of the Go release package they download and then use to build Git LFS.

As described in git-lfs/git-lfs#5477, we want to avoid any deviation from the use of this verified Go release package, and so before we upgrade to Go 1.21, we need to ensure the new `GOTOOLCHAIN` environment variable is set to `local` before any Go commands are executed. This will prevent the behaviour, added in Go 1.21, whereby Go may download and use a newer version of itself if it detects certain conditions, such as a Go module dependency which requires a newer version of Go than the one installed locally.  While we expect to be able to avoid such conditions in general, defining `GOTOOLCHAIN=local` will guarantee that if one occurs, Go will stop with an error rather than proceed to download and run an unverified version of itself.

For example, if we build a Docker image using `GOLANG_VERSION=1.20.1` and an appropriate SHA-256 hash for that distribution, commit a change to the `go.mod` file in a clone of the `git-lfs/git-lfs` project to specify `go 1.21.2`, and then run a container using the Docker image with the modified clone mounted in the `/src` directory, the result is the expected failure:
```
go: go.mod requires go >= 1.21.2 (running go 1.21.1; GOTOOLCHAIN=local)
make: *** [Makefile:598: vendor] Error 1
```