### PR TITLE
Install from `vault.centos.org` for CentOS 7

### DIFF
--- a/centos_7.Dockerfile
+++ b/centos_7.Dockerfile
@@ -6,8 +6,17 @@ LABEL RUN="docker run -v git-lfs-repo-dir:/src -v repo_dir:/repo"
 
 ENV GIT_SHA256=26831c5e48a8c2bf6a4fede1b38e1e51ffd6dad85952cf69ac520ebd81a5ae82
 
+RUN sed -i 's/mirror\.centos\.org/vault.centos.org/g' /etc/yum.repos.d/*.repo
+RUN sed -i 's/^# *baseurl=/baseurl=/' /etc/yum.repos.d/*.repo
+RUN sed -i 's/^mirrorlist=/#mirrorlist=/' /etc/yum.repos.d/*.repo
+
 RUN yum -y upgrade
 RUN yum install -y centos-release-scl
+
+RUN sed -i 's/mirror\.centos\.org/vault.centos.org/g' /etc/yum.repos.d/CentOS-SCLo-scl*.repo
+RUN sed -i 's/^# *baseurl=/baseurl=/' /etc/yum.repos.d/CentOS-SCLo-scl*.repo
+RUN sed -i 's/^mirrorlist=/#mirrorlist=/' /etc/yum.repos.d/CentOS-SCLo-scl*.repo
+
 RUN yum install -y rsync rh-ruby30-ruby rh-ruby30-build gcc
 RUN yum install -y gettext-devel libcurl-devel openssl-devel perl-CPAN perl-devel zlib-devel make wget autoconf && \
   wget https://mirrors.edge.kernel.org/pub/software/scm/git/git-2.34.5.tar.gz -O git.tar.gz && \


### PR DESCRIPTION
CentOS 7 reached its EOL in June 2024, and so the `mirror.centos.org` and `mirrorlist.centos.org` domains no longer resolve, which means our `build-docker` CI [job](https://github.com/git-lfs/git-lfs/blob/fc61febe9cc2d9ddc6ffe3e8d1ae546512632552/.github/workflows/ci.yml#L176-L188) in the main `git-lfs/git-lfs` project is now [failing](https://github.com/git-lfs/git-lfs/actions/runs/9747225509/job/26916598517).

As we hope to be able to [provide](https://github.com/git-lfs/git-lfs/blob/fc61febe9cc2d9ddc6ffe3e8d1ae546512632552/script/lib/distro.rb#L38) Git LFS release packages for SUSE Linux Enterprise Server 12.5 until its long-term support ends in October 2027, or at least until its regular support ends in October 2024, we want to continue building Docker images with CentOS 7 if possible until then.

For that reason, we update our CentOS 7 `Dockerfile` to rewrite the files under `/etc/yum.repos.d` to point to `vault.centos.org` instead. We need to comment the `mirrorlist` entries and uncomment the `baseurl` ones, and we also have to repeat this process for the new files added after the `centos-release-scl` package is installed.

A successful [run](https://github.com/chrisd8088/git-lfs/actions/runs/9768656872/job/26966623922) of the main `git-lfs/git-lfs` project's `build-docker` CI job using this branch demonstrates these changes are effective.