### PR TITLE
Upgrade Go to 1.23.3

### DIFF
--- a/build_dockers.bsh
+++ b/build_dockers.bsh
@@ -21,13 +21,13 @@ do
   esac
 done
 
-: ${GOLANG_VERSION:=1.23.1}
+: ${GOLANG_VERSION:=1.23.3}
 case "$GOLANG_ARCH" in
   amd64)
-    : ${GOLANG_SHA256:=49bbb517cfa9eee677e1e7897f7cf9cfdbcf49e05f61984a2789136de359f9bd}
+    : ${GOLANG_SHA256:=a0afb9744c00648bafb1b90b4aba5bdb86f424f02f9275399ce0c20b93a2c3a8}
     ;;
   arm64)
-    : ${GOLANG_SHA256:=faec7f7f8ae53fda0f3d408f52182d942cc89ef5b7d3d9f23ff117437d4b2d2f}
+    : ${GOLANG_SHA256:=1f7cbd7f668ea32a107ecd41b6488aaee1f5d77a66efd885b175494439d4e1ce}
     ;;
 esac
 export GOLANG_VERSION GOLANG_SHA256 GOLANG_ARCH

--- a/centos_7.Dockerfile
+++ b/centos_7.Dockerfile
@@ -28,8 +28,8 @@ RUN yum install -y gettext-devel libcurl-devel openssl-devel perl-CPAN perl-deve
   make install && \
   git --version
 
-ARG GOLANG_VERSION=1.23.1
-ARG GOLANG_SHA256=49bbb517cfa9eee677e1e7897f7cf9cfdbcf49e05f61984a2789136de359f9bd
+ARG GOLANG_VERSION=1.23.3
+ARG GOLANG_SHA256=a0afb9744c00648bafb1b90b4aba5bdb86f424f02f9275399ce0c20b93a2c3a8
 ARG GOLANG_ARCH=amd64
 
 ENV GOROOT=/usr/local/go

--- a/centos_8.Dockerfile
+++ b/centos_8.Dockerfile
@@ -4,8 +4,8 @@ RUN yum -y upgrade
 RUN yum install -y rsync ruby ruby-devel rubygems-devel gcc
 RUN yum install -y gettext-devel libcurl-devel openssl-devel perl-CPAN perl-devel zlib-devel make wget autoconf git
 
-ARG GOLANG_VERSION=1.23.1
-ARG GOLANG_SHA256=49bbb517cfa9eee677e1e7897f7cf9cfdbcf49e05f61984a2789136de359f9bd
+ARG GOLANG_VERSION=1.23.3
+ARG GOLANG_SHA256=a0afb9744c00648bafb1b90b4aba5bdb86f424f02f9275399ce0c20b93a2c3a8
 ARG GOLANG_ARCH=amd64
 
 ENV GOROOT=/usr/local/go

--- a/debian_10.Dockerfile
+++ b/debian_10.Dockerfile
@@ -6,8 +6,8 @@ LABEL RUN="docker run -v git-lfs-checkout-dir:/src -v repo_dir:/repo"
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y update && \
 apt-get install -y gettext git dpkg-dev dh-golang asciidoctor curl
 
-ARG GOLANG_VERSION=1.23.1
-ARG GOLANG_SHA256=49bbb517cfa9eee677e1e7897f7cf9cfdbcf49e05f61984a2789136de359f9bd
+ARG GOLANG_VERSION=1.23.3
+ARG GOLANG_SHA256=a0afb9744c00648bafb1b90b4aba5bdb86f424f02f9275399ce0c20b93a2c3a8
 ARG GOLANG_ARCH=amd64
 
 ENV GOROOT=/usr/local/go

--- a/debian_11.Dockerfile
+++ b/debian_11.Dockerfile
@@ -8,8 +8,8 @@ RUN dpkg --add-architecture i386
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y update && \
 apt-get install -y --no-install-recommends gettext git dpkg-dev dh-golang asciidoctor curl build-essential gcc-i686-linux-gnu libc6-dev:i386
 
-ARG GOLANG_VERSION=1.23.1
-ARG GOLANG_SHA256=49bbb517cfa9eee677e1e7897f7cf9cfdbcf49e05f61984a2789136de359f9bd
+ARG GOLANG_VERSION=1.23.3
+ARG GOLANG_SHA256=a0afb9744c00648bafb1b90b4aba5bdb86f424f02f9275399ce0c20b93a2c3a8
 ARG GOLANG_ARCH=amd64
 
 ENV GOROOT=/usr/local/go

--- a/debian_12.Dockerfile
+++ b/debian_12.Dockerfile
@@ -8,8 +8,8 @@ RUN dpkg --add-architecture i386
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y update && \
 apt-get install -y --no-install-recommends gettext git dpkg-dev dh-golang asciidoctor curl build-essential gcc-i686-linux-gnu libc6-dev:i386
 
-ARG GOLANG_VERSION=1.23.1
-ARG GOLANG_SHA256=49bbb517cfa9eee677e1e7897f7cf9cfdbcf49e05f61984a2789136de359f9bd
+ARG GOLANG_VERSION=1.23.3
+ARG GOLANG_SHA256=a0afb9744c00648bafb1b90b4aba5bdb86f424f02f9275399ce0c20b93a2c3a8
 ARG GOLANG_ARCH=amd64
 
 ENV GOROOT=/usr/local/go

--- a/rocky_9.Dockerfile
+++ b/rocky_9.Dockerfile
@@ -4,8 +4,8 @@ RUN dnf -y upgrade
 RUN dnf install -y rsync ruby ruby-devel rubygems-devel gcc
 RUN dnf install -y gettext-devel libcurl-devel openssl-devel perl-CPAN perl-devel zlib-devel make wget autoconf git
 
-ARG GOLANG_VERSION=1.23.1
-ARG GOLANG_SHA256=49bbb517cfa9eee677e1e7897f7cf9cfdbcf49e05f61984a2789136de359f9bd
+ARG GOLANG_VERSION=1.23.3
+ARG GOLANG_SHA256=a0afb9744c00648bafb1b90b4aba5bdb86f424f02f9275399ce0c20b93a2c3a8
 ARG GOLANG_ARCH=amd64
 
 ENV GOROOT=/usr/local/go


### PR DESCRIPTION
Using our `update-hashes` script we upgrade our Docker builds to the same version of Go currently used by our main project's CI suite, which is Go version 1.23.3.