### PR TITLE
Install Asciidoctor RPM package on RHEL/CentOS/Rocky Linux platforms

### DIFF
--- a/centos_8.Dockerfile
+++ b/centos_8.Dockerfile
@@ -1,8 +1,12 @@
 FROM rockylinux/rockylinux:8
 
 RUN yum -y upgrade
-RUN yum install -y rsync ruby ruby-devel rubygems-devel gcc
+RUN yum install -y rsync ruby ruby-devel rubygems-devel gcc yum-utils
 RUN yum install -y gettext-devel libcurl-devel openssl-devel perl-CPAN perl-devel zlib-devel make wget autoconf git
+
+RUN yum-config-manager --enable powertools
+RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+RUN yum install -y rubygem-asciidoctor
 
 ARG GOLANG_VERSION=1.24.4
 ARG GOLANG_SHA256=77e5da33bb72aeaef1ba4418b6fe511bc4d041873cbf82e5aa6318740df98717

--- a/rocky_10.Dockerfile
+++ b/rocky_10.Dockerfile
@@ -1,8 +1,12 @@
 FROM rockylinux/rockylinux:10
 
 RUN dnf -y upgrade
-RUN dnf install -y rsync ruby ruby-devel rubygems-devel gcc
+RUN dnf install -y rsync ruby ruby-devel rubygems-devel gcc 'dnf-command(config-manager)'
 RUN dnf install -y gettext-devel libcurl-devel openssl-devel perl-CPAN perl-devel zlib-devel make wget autoconf git
+
+RUN dnf config-manager --set-enabled crb
+RUN dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-10.noarch.rpm
+RUN dnf install -y rubygem-asciidoctor
 
 ARG GOLANG_VERSION=1.24.4
 ARG GOLANG_SHA256=77e5da33bb72aeaef1ba4418b6fe511bc4d041873cbf82e5aa6318740df98717

--- a/rocky_9.Dockerfile
+++ b/rocky_9.Dockerfile
@@ -1,8 +1,12 @@
 FROM rockylinux/rockylinux:9
 
 RUN dnf -y upgrade
-RUN dnf install -y rsync ruby ruby-devel rubygems-devel gcc
+RUN dnf install -y rsync ruby ruby-devel rubygems-devel gcc 'dnf-command(config-manager)'
 RUN dnf install -y gettext-devel libcurl-devel openssl-devel perl-CPAN perl-devel zlib-devel make wget autoconf git
+
+RUN dnf config-manager --set-enabled crb
+RUN dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
+RUN dnf install -y rubygem-asciidoctor
 
 ARG GOLANG_VERSION=1.24.4
 ARG GOLANG_SHA256=77e5da33bb72aeaef1ba4418b6fe511bc4d041873cbf82e5aa6318740df98717


### PR DESCRIPTION
In PR git-lfs/git-lfs#5054 we updated the source files of the manual pages for the Git LFS client from the Ronn format to the AsciiDoc format, which necessitated changing our Linux package build processes to use the Asciidoctor Ruby gem to generate manual pages in Roff and HTML formats.

At the time, an RPM package for a 2.0.x version of the Asciidoctor Ruby gem was not easily available for all the platforms based on Red Hat Enterprise Linux (RHEL) that we supported, particularly RHEL/CentOS 7, so in commit git-lfs/git-lfs@db9a82132a2bb066876d8ddf06c5255da2f199a4 of PR git-lfs/git-lfs#5054 we updated the `rpm/build_rpms.bsh` script in our main project's repository to [build](https://github.com/git-lfs/git-lfs/blob/9e751d16509c9d65bda15b53c7d30a583c66e0c8/rpm/build_rpms.bsh#L42-L53) and install a custom RPM package with Asciidoctor v2.0.17.  In the same commit we also defined a SPEC [file](https://github.com/git-lfs/git-lfs/blob/9e751d16509c9d65bda15b53c7d30a583c66e0c8/rpm/SPECS/rubygem-asciidoctor.spec) for this custom rubygem-asciidoctor RPM package in the `rpm/SPECS` directory in our main project.

However, as noted in commit cfde13039f369d3964ef1d62f8c248b40ce6b680 of PR #71, all the distribution versions based on RHEL 7, CentOS 7, and SUSE Linux Enterprise Server (SLES) 12 for which we previously built RPM packages have now reached the end of their standard LTS (Long-Term Support) periods, and so future releases of the Git LFS client will no longer build packages for them.

This change means we will not need to build and install a custom RPM package for Asciidoctor any more, because there are `rubygem-asciidoctor` packages [available](https://packages.fedoraproject.org/pkgs/rubygem-asciidoctor/rubygem-asciidoctor/) in the Extra Packages for Enterprise Linux (EPEL) collection which provide Asciidoctor v2.0.15 or higher for each of the RHEL/CentOS 8, RHEL/Rocky Linux 9, and RHEL/Rocky Linux 10 platforms.

We therefore update our `Dockerfile`s for these platforms to install the `rubygem-asciidoctor` package.  As this package is available from the EPEL collection, we first need to enable the PowerTools (for RHEL/CentOS 7) or CodeReady Linux Builder (CRB) repository, and then install the EPEL package, before installing the `rubygem-asciidoctor` package, as [described](https://docs.fedoraproject.org/en-US/epel/getting-started/) in the Fedora Project documentation.

Once this PR is merged, we can then update the `rpm/build_rpms.bsh` script in our main project so it skips trying to build or install a custom RPM package for Asciidoctor, and we can remove the corresponding SPEC file for that package as well.