### PR TITLE
Upgrade Go to 1.25.3

### DIFF
--- a/centos_8.Dockerfile
+++ b/centos_8.Dockerfile
@@ -8,8 +8,8 @@ RUN yum-config-manager --enable powertools
 RUN yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
 RUN yum install -y rubygem-asciidoctor
 
-ARG GOLANG_VERSION=1.24.4
-ARG GOLANG_SHA256=77e5da33bb72aeaef1ba4418b6fe511bc4d041873cbf82e5aa6318740df98717
+ARG GOLANG_VERSION=1.25.3
+ARG GOLANG_SHA256=0335f314b6e7bfe08c3d0cfaa7c19db961b7b99fb20be62b0a826c992ad14e0f
 ARG GOLANG_ARCH=amd64
 
 ENV GOROOT=/usr/local/go

--- a/debian_11.Dockerfile
+++ b/debian_11.Dockerfile
@@ -8,8 +8,8 @@ RUN dpkg --add-architecture i386
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y update && \
 apt-get install -y --no-install-recommends gettext git dpkg-dev dh-golang asciidoctor curl build-essential gcc-i686-linux-gnu libc6-dev:i386
 
-ARG GOLANG_VERSION=1.24.4
-ARG GOLANG_SHA256=77e5da33bb72aeaef1ba4418b6fe511bc4d041873cbf82e5aa6318740df98717
+ARG GOLANG_VERSION=1.25.3
+ARG GOLANG_SHA256=0335f314b6e7bfe08c3d0cfaa7c19db961b7b99fb20be62b0a826c992ad14e0f
 ARG GOLANG_ARCH=amd64
 
 ENV GOROOT=/usr/local/go

--- a/debian_12.Dockerfile
+++ b/debian_12.Dockerfile
@@ -8,8 +8,8 @@ RUN dpkg --add-architecture i386
 RUN DEBIAN_FRONTEND=noninteractive apt-get -y update && \
 apt-get install -y --no-install-recommends gettext git dpkg-dev dh-golang asciidoctor curl build-essential gcc-i686-linux-gnu libc6-dev:i386
 
-ARG GOLANG_VERSION=1.24.4
-ARG GOLANG_SHA256=77e5da33bb72aeaef1ba4418b6fe511bc4d041873cbf82e5aa6318740df98717
+ARG GOLANG_VERSION=1.25.3
+ARG GOLANG_SHA256=0335f314b6e7bfe08c3d0cfaa7c19db961b7b99fb20be62b0a826c992ad14e0f
 ARG GOLANG_ARCH=amd64
 
 ENV GOROOT=/usr/local/go

--- a/rocky_10.Dockerfile
+++ b/rocky_10.Dockerfile
@@ -8,8 +8,8 @@ RUN dnf config-manager --set-enabled crb
 RUN dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-10.noarch.rpm
 RUN dnf install -y rubygem-asciidoctor
 
-ARG GOLANG_VERSION=1.24.4
-ARG GOLANG_SHA256=77e5da33bb72aeaef1ba4418b6fe511bc4d041873cbf82e5aa6318740df98717
+ARG GOLANG_VERSION=1.25.3
+ARG GOLANG_SHA256=0335f314b6e7bfe08c3d0cfaa7c19db961b7b99fb20be62b0a826c992ad14e0f
 ARG GOLANG_ARCH=amd64
 
 ENV GOROOT=/usr/local/go

--- a/rocky_9.Dockerfile
+++ b/rocky_9.Dockerfile
@@ -8,8 +8,8 @@ RUN dnf config-manager --set-enabled crb
 RUN dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm
 RUN dnf install -y rubygem-asciidoctor
 
-ARG GOLANG_VERSION=1.24.4
-ARG GOLANG_SHA256=77e5da33bb72aeaef1ba4418b6fe511bc4d041873cbf82e5aa6318740df98717
+ARG GOLANG_VERSION=1.25.3
+ARG GOLANG_SHA256=0335f314b6e7bfe08c3d0cfaa7c19db961b7b99fb20be62b0a826c992ad14e0f
 ARG GOLANG_ARCH=amd64
 
 ENV GOROOT=/usr/local/go


### PR DESCRIPTION
Using our `update-hashes` script we upgrade our Docker builds to the same version of Go currently used by our main project's CI suite, which is Go version 1.25.3.