### PR TITLE
Add Debian 13 support

### DIFF
--- a/debian_11.Dockerfile
+++ b/debian_11.Dockerfile
@@ -24,4 +24,4 @@ RUN cd /usr/local && \
 
 COPY debian_script.bsh /tmp/
 
-CMD /tmp/debian_script.bsh
+CMD /tmp/debian_script.bsh --add-i386

--- a/debian_12.Dockerfile
+++ b/debian_12.Dockerfile
@@ -24,4 +24,4 @@ RUN cd /usr/local && \
 
 COPY debian_script.bsh /tmp/
 
-CMD /tmp/debian_script.bsh
+CMD /tmp/debian_script.bsh --add-i386

--- a/debian_13.Dockerfile
+++ b/debian_13.Dockerfile
@@ -1,0 +1,25 @@
+FROM debian:trixie
+
+#Docker RUN example, pass in the git-lfs checkout copy you are working with
+LABEL RUN="docker run -v git-lfs-checkout-dir:/src -v repo_dir:/repo"
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get -y update && \
+apt-get install -y --no-install-recommends gettext git dpkg-dev dh-golang asciidoctor curl build-essential
+
+ARG GOLANG_VERSION=1.25.3
+ARG GOLANG_SHA256=0335f314b6e7bfe08c3d0cfaa7c19db961b7b99fb20be62b0a826c992ad14e0f
+ARG GOLANG_ARCH=amd64
+
+ENV GOROOT=/usr/local/go
+ENV GOTOOLCHAIN=local
+
+RUN cd /usr/local && \
+    curl -L -O https://golang.org/dl/go${GOLANG_VERSION}.linux-${GOLANG_ARCH}.tar.gz && \
+    [ "$(sha256sum go${GOLANG_VERSION}.linux-${GOLANG_ARCH}.tar.gz | cut -d' ' -f1)" = "${GOLANG_SHA256}" ] && \
+    tar zxf go${GOLANG_VERSION}.linux-${GOLANG_ARCH}.tar.gz && \
+    ln -s /usr/local/go/bin/go /usr/bin/go && \
+    ln -s /usr/local/go/bin/gofmt /usr/bin/gofmt
+
+COPY debian_script.bsh /tmp/
+
+CMD /tmp/debian_script.bsh

--- a/debian_script.bsh
+++ b/debian_script.bsh
@@ -8,6 +8,10 @@ case "$(uname -m)" in
     ARCH=arm64;;
 esac
 
+if [ "$ARCH" = "amd64" ] && [ "$#" -eq 1 ] && [ "$1" = "--add-i386" ]; then
+  ARCH="$ARCH i386"
+fi
+
 REPO_DIR=${REPO_DIR:-/repo}
 GIT_LFS_BUILD_DIR=${GIT_LFS_BUILD_DIR:-/tmp/docker_run/src/git-lfs}
 SRC_DIR=${SRC_DIR:-/src}
@@ -31,19 +35,11 @@ move_architecture () {
 }
 
 mkdir -p ${GIT_LFS_BUILD_DIR}
-case "$ARCH" in
-  amd64)
-    process_architecture i386
-    process_architecture amd64
 
-    move_architecture i386
-    move_architecture amd64
-    ;;
-  arm64)
-    process_architecture arm64
-    move_architecture arm64
-    ;;
-esac
+for arch in $ARCH; do
+  process_architecture "$arch"
+  move_architecture "$arch"
+done
 
 if [ "${FINAL_UID-}:${FINAL_GID-}" != ":" ]; then
   chown ${FINAL_UID-}:${FINAL_GID-} -R "${REPO_DIR}"


### PR DESCRIPTION
As the Debian 13 ("trixie") platform was officially released in August 2025, we should now build a Git LFS binary package for it, rather than continuing to use Debian 12 for this purpose.

We therefore add a `Dockerfile` which will build a Git LFS binary on the Debian 13 platform.  Note that we will only build a 64-bit binary on this platform, since users with 32-bit systems are encouraged to remain on Debian 12, per the Debian 13 release [announcement](https://www.debian.org/News/2025/20250809).

As we still want to build 32-bit binaries on the Debian 11 and 12 platforms, we update our existing `Dockerfile`s for those platforms so they pass an explicit `--add-i386` option to the `debian_script.bsh` shell script, and we revise the script so that it only builds a Git LFS binary for the `i386` architecture if the new option is specified and if the current system architecture is `amd64`.

This PR's changes have been tested with the GitHub Actions CI and release workflows of our main project using a private repository.

Note that we will update the version of Go we use in our Docker images in a subsequent PR; for the moment we simply use the same version in our new `Dockerfile` as appears in our existing `Dockerfile`s.