### PR TITLE
Build RHEL/Rocky Linux 10 only for 64-bit systems

### DIFF
--- a/centos_8.Dockerfile
+++ b/centos_8.Dockerfile
@@ -24,4 +24,4 @@ RUN cd /usr/local && \
 
 COPY centos_script.bsh /tmp/
 
-CMD /tmp/centos_script.bsh
+CMD /tmp/centos_script.bsh --add-i386

--- a/centos_script.bsh
+++ b/centos_script.bsh
@@ -12,7 +12,7 @@ cp -r -T "${SRC_DIR}" "${GIT_LFS_BUILD_DIR}"
 
 cd "${GIT_LFS_BUILD_DIR}"
 git clean -xdf .
-rpm/build_rpms.bsh
+rpm/build_rpms.bsh "$@"
 
 rsync -ra --include='*/' --include='git-lfs*' --exclude='*' \
   "${GIT_LFS_BUILD_DIR}"/rpm/{SRPMS,RPMS} "${REPO_DIR}"

--- a/rocky_9.Dockerfile
+++ b/rocky_9.Dockerfile
@@ -24,4 +24,4 @@ RUN cd /usr/local && \
 
 COPY centos_script.bsh /tmp/
 
-CMD /tmp/centos_script.bsh
+CMD /tmp/centos_script.bsh --add-i386


### PR DESCRIPTION
This PR updates our `Dockerfile`s and scripts for Red Hat Enterprise Linux (RHEL) platforms so that we will only build 32-bit binaries of Git LFS for RHEL versions earlier than RHEL 10.0.

Note that to make this PR's changes fully effective we will also require a PR in our main project's repository to adjust the [script](https://github.com/git-lfs/git-lfs/blob/12137348e03e290e6535f3eaeffb6c4c20de96ce/rpm/build_rpms.bsh) in that project that we run to build RPM pacakges.

This PR's changes have been tested with the GitHub Actions CI and release workflows of our main project using a private repository.

#### Details

In commit ca43a08d00b5441a5284e22cf5cf0149dba0fb71 of PR #75 we introduced a new `--add-i386` option to the `debian_script.bsh` shell script and revised the script so that it only builds a Git LFS binary for the `i386` architecture if the new option is specified and if the current system architecture is AMD64.  We also updated our `Dockerfile`s for the Debian 11 and 12 platforms so they passed the new option to the `debian_script.bsh` script.

We made these changes so that we could then add a new `Dockerfile` for the Debian 13 platform and explicitly not pass the `--add-i386` option to the `debian_script.bsh` script in that `Dockerfile`, because Debian 13 is not recommended for 32-bit systems.

The Red Hat Enterprise Linux (RHEL) 10.0 and Rocky Linux 10.0 platforms likewise also only provide support for 64-bit systems, as noted in their [release](https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/10/html-single/10.0_release_notes/index) [announcements](https://rockylinux.org/news/rocky-linux-10-0-ga-release).

However, when we added a `Dockerfile` to build RPM packages of Git LFS for these platforms, we did not take into account the fact that this `Dockerfile` should only build a 64-bit Git LFS binary.  Specifically, the `rocky_10.Dockerfile` file that we added in commit cc16329409175a2120e7306499b30304689b07f8 of PR #71 simply follows the same set of steps as our `Dockerfile`s for the earlier RHEL/CentOS 8 and RHEL/Rocky Linux 9 platforms, and so builds both 32-bit and 64-bit binaries in two separate RPM packages.

To help resolve this issue, we now update our Dockerfiles for RHEL/CentOS 8 and RHEL/Rocky Linux 9 so they pass an explicit `--add-i386` option to the `centos_script.bsh` shell script, and we revise the script so that it passes its command-line arguments through to the `rpm/build_rpms.bsh` [script](https://github.com/git-lfs/git-lfs/blob/12137348e03e290e6535f3eaeffb6c4c20de96ce/rpm/build_rpms.bsh) from our main project's repository.

In a subsequent PR in our `git-lfs/git-lfs` repository we will update the `rpm/build_rpms.bsh` script so that it only builds a package with a 32-bit binary if the `--add-i386` option is provided.  Because our `Dockerfile` for the RHEL/Rocky Linux 10 platform will not pass this option to the `centos_script.bsh` script, the `rpm/build_rpms.bsh` script will then build only one package with a 64-bit Git LFS binary, as we would prefer it to do for this platform.